### PR TITLE
feat(debug): add DEBUG_ANALYSIS=1 offline iteration mode

### DIFF
--- a/ui/pages/loading.py
+++ b/ui/pages/loading.py
@@ -383,6 +383,18 @@ def render_loading(source: Any) -> None:
         return
     _advance("ingestion", t0)
 
+    # Debug hook: save raw audio for iterative debugging without re-ingesting.
+    # Gate: DEBUG_ANALYSIS=1. All files land in debug/ (gitignored).
+    if os.getenv("DEBUG_ANALYSIS"):
+        import re as _re
+        from pathlib import Path as _Path
+        _debug_dir = _Path(__file__).parent.parent.parent / "debug"
+        _debug_dir.mkdir(exist_ok=True)
+        _safe = _re.sub(r"[^\w\-]", "_", audio.label)[:60]
+        _dest = _debug_dir / f"{_safe}.wav"
+        _dest.write_bytes(audio.raw)
+        print(f"[DEBUG_ANALYSIS] Audio saved → {_dest}")
+
     # ── Step 2: Structure analysis (title/artist needed for lyrics lookup) ──
     _tick("Analysing Structure")
     t0 = time.time()
@@ -511,6 +523,36 @@ def render_loading(source: Any) -> None:
         similar_tracks=similar,
         legal=legal,
     )
+
+    # Debug hook: save forensics scores + full result JSON for offline iteration.
+    # Runs only when DEBUG_ANALYSIS=1 — never in production.
+    if os.getenv("DEBUG_ANALYSIS"):
+        import json as _json
+        import re as _re
+        from pathlib import Path as _Path
+        _debug_dir = _Path(__file__).parent.parent.parent / "debug"
+        _debug_dir.mkdir(exist_ok=True)
+        _safe = _re.sub(r"[^\w\-]", "_", audio.label)[:60]
+        if forensics is not None:
+            _fdest = _debug_dir / f"{_safe}_forensics.json"
+            _fdest.write_text(_json.dumps(forensics.model_dump(), indent=2))
+            print(f"[DEBUG_ANALYSIS] Forensics saved → {_fdest}")
+        _rdest = _debug_dir / f"{_safe}_result.json"
+        _rdest.write_text(result.to_json())
+        print(f"[DEBUG_ANALYSIS] Result saved   → {_rdest}")
+        # Save the label the user selected on the portal before scanning
+        _debug_label = st.session_state.pop("debug_label", None)
+        if _debug_label and _debug_label != "— unrated —":
+            _labels_file = _debug_dir / "labels.json"
+            _existing: dict = {}
+            if _labels_file.exists():
+                try:
+                    _existing = _json.loads(_labels_file.read_text())
+                except Exception:
+                    pass
+            _existing[audio.label] = _debug_label
+            _labels_file.write_text(_json.dumps(_existing, indent=2, ensure_ascii=False))
+            print(f"[DEBUG_ANALYSIS] Label saved    → {audio.label}: {_debug_label}")
 
     st.session_state.audio    = audio
     st.session_state.analysis = result

--- a/ui/pages/portal.py
+++ b/ui/pages/portal.py
@@ -6,10 +6,26 @@ on communication and the portal page can focus on the task.
 """
 from __future__ import annotations
 
+import json
+import os
+from pathlib import Path
+
 import streamlit as st
 
 from ui.components import eq_bars
 from ui.nav import render_site_nav, render_site_footer
+
+_DEBUG_DIR = Path(__file__).parent.parent.parent / "debug"
+_LABELS_FILE = _DEBUG_DIR / "labels.json"
+_LABEL_OPTIONS = [
+    "— unrated —",
+    "100% AI",
+    "AI Cover",
+    "Heavily Sampled/Loops",
+    "May Contain One-Shot Samples",
+    "Modern Production Practices",
+    "RAW",
+]
 
 
 def render_portal() -> None:
@@ -71,10 +87,18 @@ def render_portal() -> None:
                     placeholder="https://youtube.com/watch?v=...",
                     label_visibility="collapsed",
                 )
+                if os.getenv("DEBUG_ANALYSIS"):
+                    track_label = st.selectbox(
+                        "Track category",
+                        _LABEL_OPTIONS,
+                        key="portal_label_url",
+                    )
+                else:
+                    track_label = None
                 if st.button("Initiate Scan →", type="primary",
                              use_container_width=True, key="run_url"):
                     if url:
-                        _submit_source(url)
+                        _submit_source(url, track_label)
                     else:
                         st.warning("Paste a YouTube URL first.")
             else:
@@ -83,11 +107,19 @@ def render_portal() -> None:
                     type=["mp3", "wav", "flac", "m4a", "ogg"],
                     label_visibility="collapsed",
                 )
+                if os.getenv("DEBUG_ANALYSIS"):
+                    track_label = st.selectbox(
+                        "Track category",
+                        _LABEL_OPTIONS,
+                        key="portal_label_upload",
+                    )
+                else:
+                    track_label = None
                 if st.button("Initiate Scan →", type="primary",
                              use_container_width=True, key="run_upload",
                              disabled=uploaded is None):
                     if uploaded:
-                        _submit_source(uploaded)
+                        _submit_source(uploaded, track_label)
 
         st.markdown("""
         <p style="text-align:center;font-family:'JetBrains Mono',monospace;font-size:.54rem;
@@ -101,10 +133,11 @@ def render_portal() -> None:
     render_site_footer()
 
 
-def _submit_source(source: object) -> None:
+def _submit_source(source: object, track_label: str | None = None) -> None:
     """Store source in session state and route to the loading page."""
-    st.session_state.source   = source
-    st.session_state.audio    = None
-    st.session_state.analysis = None
-    st.session_state.page     = "loading"
+    st.session_state.source        = source
+    st.session_state.audio         = None
+    st.session_state.analysis      = None
+    st.session_state.debug_label   = track_label
+    st.session_state.page          = "loading"
     st.rerun()


### PR DESCRIPTION
## Summary

Adds an opt-in debug mode for local pipeline development and threshold tuning. Activated by setting DEBUG_ANALYSIS=1 in the environment. Never active in production — HF Spaces does not set this variable.

### loading.py — pipeline artifact capture
- **After ingestion**: saves raw audio to `debug/<track>.wav` so the same track can be re-analyzed without re-downloading from YouTube
- **After pipeline**: saves forensics scores to `debug/<track>_forensics.json` and full analysis result to `debug/<track>_result.json` for offline threshold tuning

### portal.py — fixture labeling
- When DEBUG_ANALYSIS=1, a Track Category selector appears above the Initiate Scan button
- Lets you label a track (e.g. clean / flagged / borderline) at scan time for use when capturing regression test fixtures with CAPTURE_RESULTS=1

All output goes to the `debug/` directory, which is gitignored.

## Test plan

- [ ] Without DEBUG_ANALYSIS set: no debug output, portal shows no label selector
- [ ] With DEBUG_ANALYSIS=1: `debug/` directory populated after a scan, label selector visible in portal
- [ ] Confirm `debug/` does not appear in `git status`

Generated with [Claude Code](https://claude.com/claude-code)