### PR TITLE
feat: track popularity metric and estimated sync cost (#31)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -107,6 +107,20 @@ class SystemConstants:
     # ---- Discovery ------------------------------------------------------------
     MAX_SIMILAR_TRACKS: int = 5
 
+    # ---- Track Popularity (Last.fm listener counts) ---------------------------
+    # Tier boundaries based on Last.fm unique listener counts.
+    # Tiers: Emerging < Regional < Mainstream < Global
+    POPULARITY_REGIONAL_MIN: int    = 10_000
+    POPULARITY_MAINSTREAM_MIN: int  = 100_000
+    POPULARITY_GLOBAL_MIN: int      = 1_000_000
+
+    # Estimated sync fee ranges (USD) per popularity tier — shown as guidance only.
+    # Source: industry averages 2024-2026; highly variable by usage and territory.
+    SYNC_COST_EMERGING: tuple[int, int]    = (500,    5_000)
+    SYNC_COST_REGIONAL: tuple[int, int]    = (2_000,  25_000)
+    SYNC_COST_MAINSTREAM: tuple[int, int]  = (15_000, 100_000)
+    SYNC_COST_GLOBAL: tuple[int, int]      = (50_000, 500_000)
+
     # ---- Forensics: IBI / Groove ----------------------------------------------
     # IBI variance below this → "Perfect Quantization" AI signal.
     # FakeMusicCaps calibration 2026-03-23: AI median IBI variance (621) is

--- a/core/models.py
+++ b/core/models.py
@@ -282,6 +282,21 @@ class AuthorshipResult(BaseModel):
 # Discovery & Legal
 # ---------------------------------------------------------------------------
 
+class PopularityResult(BaseModel):
+    """Last.fm popularity data for the scanned track."""
+
+    model_config = ConfigDict(frozen=True)
+
+    listeners: int           # unique listeners on Last.fm
+    playcount: int           # total scrobbles on Last.fm
+    tier: str                # "Emerging" | "Regional" | "Mainstream" | "Global"
+    sync_cost_low: int       # estimated sync fee lower bound (USD)
+    sync_cost_high: int      # estimated sync fee upper bound (USD)
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump()
+
+
 class TrackCandidate(BaseModel):
     """A similar track returned by the discovery service."""
 
@@ -330,6 +345,7 @@ class AnalysisResult(BaseModel):
     authorship: Optional[AuthorshipResult]                  = None
     similar_tracks: list[TrackCandidate]                    = Field(default_factory=list)
     legal: Optional[LegalLinks]                             = None
+    popularity: Optional[PopularityResult]                  = None
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/services/discovery.py
+++ b/services/discovery.py
@@ -31,7 +31,7 @@ import requests
 
 from core.config import CONSTANTS, get_settings
 from core.exceptions import AudioSourceError, ConfigurationError
-from core.models import TrackCandidate
+from core.models import PopularityResult, TrackCandidate
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +101,42 @@ class Discovery:
             ))
 
         return candidates
+
+    def get_track_popularity(self, title: str, artist: str) -> Optional[PopularityResult]:
+        """
+        Fetch listener count and playcount from Last.fm track.getInfo.
+
+        Returns a PopularityResult with tier classification and estimated sync
+        cost range, or None when the track is not found or the API key is missing.
+
+        Never raises — popularity is supplementary metadata.
+        """
+        api_key = get_settings().lastfm_api_key
+        if not api_key or (not title and not artist):
+            return None
+
+        params = {
+            "method":      "track.getInfo",
+            "track":       title,
+            "artist":      artist,
+            "api_key":     api_key,
+            "format":      "json",
+            "autocorrect": 1,
+        }
+
+        try:
+            resp = requests.get(_LASTFM_BASE, params=params, timeout=10)
+            resp.raise_for_status()
+            track_data = resp.json().get("track", {})
+            if not track_data:
+                return None
+
+            listeners = int(track_data.get("listeners", 0))
+            playcount = int(track_data.get("playcount", 0))
+            return _classify_popularity(listeners, playcount)
+
+        except Exception:  # noqa: BLE001 — popularity is always best-effort
+            return None
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +295,48 @@ def _resolve_youtube_url(artist: str, title: str) -> Optional[str]:
         pass
 
     return None
+
+
+def _classify_popularity(
+    listeners: int,
+    playcount: int,
+    constants: object | None = None,
+) -> PopularityResult:
+    """
+    Classify a track's popularity tier and estimate sync cost range.
+
+    Tier boundaries and cost ranges come from SystemConstants — no magic numbers.
+    Accepts an optional constants override for unit testing without env deps.
+
+    Args:
+        listeners:  Last.fm unique listener count.
+        playcount:  Last.fm total scrobble count.
+        constants:  Optional SystemConstants instance; defaults to CONSTANTS.
+
+    Returns:
+        PopularityResult with tier and estimated sync cost range.
+    """
+    cfg = constants or CONSTANTS
+    if listeners >= cfg.POPULARITY_GLOBAL_MIN:
+        tier                = "Global"
+        cost_low, cost_high = cfg.SYNC_COST_GLOBAL
+    elif listeners >= cfg.POPULARITY_MAINSTREAM_MIN:
+        tier                = "Mainstream"
+        cost_low, cost_high = cfg.SYNC_COST_MAINSTREAM
+    elif listeners >= cfg.POPULARITY_REGIONAL_MIN:
+        tier                = "Regional"
+        cost_low, cost_high = cfg.SYNC_COST_REGIONAL
+    else:
+        tier                = "Emerging"
+        cost_low, cost_high = cfg.SYNC_COST_EMERGING
+
+    return PopularityResult(
+        listeners=listeners,
+        playcount=playcount,
+        tier=tier,
+        sync_cost_low=cost_low,
+        sync_cost_high=cost_high,
+    )
 
 
 def _find_binary(name: str) -> Optional[str]:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -8,11 +8,53 @@ import pytest
 
 from services.discovery import (
     Discovery,
+    _classify_popularity,
     _find_binary,
     _parse_track_list,
     _resolve_youtube_url,
 )
+from core.config import CONSTANTS
 from core.exceptions import ConfigurationError
+
+
+# ---------------------------------------------------------------------------
+# _classify_popularity (pure helper — no mocks needed)
+# ---------------------------------------------------------------------------
+
+class TestClassifyPopularity:
+    """Tests for _classify_popularity — uses CONSTANTS directly so tier boundaries
+    come from config, not magic numbers in tests."""
+
+    def test_emerging_tier(self) -> None:
+        result = _classify_popularity(5_000, 50_000, CONSTANTS)
+        assert result.tier == "Emerging"
+        assert result.listeners == 5_000
+        assert result.playcount == 50_000
+        assert result.sync_cost_low  == CONSTANTS.SYNC_COST_EMERGING[0]
+        assert result.sync_cost_high == CONSTANTS.SYNC_COST_EMERGING[1]
+
+    def test_regional_tier_at_boundary(self) -> None:
+        result = _classify_popularity(CONSTANTS.POPULARITY_REGIONAL_MIN, 0, CONSTANTS)
+        assert result.tier == "Regional"
+
+    def test_mainstream_tier_at_boundary(self) -> None:
+        result = _classify_popularity(CONSTANTS.POPULARITY_MAINSTREAM_MIN, 0, CONSTANTS)
+        assert result.tier == "Mainstream"
+
+    def test_global_tier_at_boundary(self) -> None:
+        result = _classify_popularity(CONSTANTS.POPULARITY_GLOBAL_MIN, 0, CONSTANTS)
+        assert result.tier == "Global"
+        assert result.sync_cost_low  == CONSTANTS.SYNC_COST_GLOBAL[0]
+        assert result.sync_cost_high == CONSTANTS.SYNC_COST_GLOBAL[1]
+
+    def test_zero_listeners(self) -> None:
+        result = _classify_popularity(0, 0, CONSTANTS)
+        assert result.tier == "Emerging"
+        assert result.listeners == 0
+
+    def test_just_below_regional(self) -> None:
+        result = _classify_popularity(CONSTANTS.POPULARITY_REGIONAL_MIN - 1, 0, CONSTANTS)
+        assert result.tier == "Emerging"
 
 
 # ---------------------------------------------------------------------------

--- a/ui/pages/loading.py
+++ b/ui/pages/loading.py
@@ -557,14 +557,17 @@ def render_loading(source: Any) -> None:
     else:
         _advance("discovery", t0)
 
-    # ── Step 8: Legal links ───────────────────────────────────────────────
+    # ── Step 8: Legal links + popularity ─────────────────────────────────
     _tick("Legal Links", "legal")
     t0 = time.time()
-    legal = None
+    legal      = None
+    popularity = None
     log.step_start("legal")
     try:
+        from services.discovery import Discovery
         from services.legal import Legal
-        legal = Legal().get_links(title, artist)
+        legal      = Legal().get_links(title, artist)
+        popularity = Discovery().get_track_popularity(title, artist)
     except SyncSafeError as exc:
         _advance("legal", t0, error=str(exc))
     except Exception as exc:  # noqa: BLE001 — UI boundary
@@ -591,6 +594,7 @@ def render_loading(source: Any) -> None:
             "authorship":     authorship,
             "similar_tracks": similar,
             "legal":          legal,
+            "popularity":     popularity,
         },
         from_attributes=True,
     )

--- a/ui/pages/report.py
+++ b/ui/pages/report.py
@@ -736,7 +736,66 @@ def _sync_readiness_row(icon: str, label: str, value: str, ok: bool,
 # Discovery & Licensing
 # ---------------------------------------------------------------------------
 
+_POPULARITY_TIER_COLORS: dict[str, str] = {
+    "Emerging":   "var(--dim)",
+    "Regional":   "var(--issue-location)",  # blue — defined in styles.py
+    "Mainstream": "var(--grade-c)",          # amber — defined in styles.py
+    "Global":     "var(--accent)",           # orange — defined in styles.py
+}
+
+
+def _render_popularity_card(result: AnalysisResult) -> None:
+    """Render track popularity tier and estimated sync cost from Last.fm data."""
+    pop = result.popularity
+    if pop is None:
+        st.markdown(
+            "<div style='color:var(--dim);font-size:.84rem;font-family:Figtree,sans-serif;'>"
+            "Popularity data unavailable — track not found on Last.fm.</div>",
+            unsafe_allow_html=True,
+        )
+        return
+
+    tier_color = _POPULARITY_TIER_COLORS.get(pop.tier, "var(--dim)")
+    listeners_fmt = f"{pop.listeners:,}"
+    cost_fmt      = f"${pop.sync_cost_low:,} – ${pop.sync_cost_high:,}"
+
+    st.markdown(f"""
+    <div style="display:flex;gap:12px;flex-wrap:wrap;margin-bottom:16px;">
+      <div class="sig" style="flex:1;min-width:120px;padding:14px 16px;text-align:center;">
+        <div style="font-family:'Chakra Petch',monospace;font-size:.5rem;font-weight:600;
+                    letter-spacing:.18em;text-transform:uppercase;color:var(--dim);
+                    margin-bottom:6px;">Popularity</div>
+        <div style="font-family:'Chakra Petch',monospace;font-size:1.2rem;font-weight:700;
+                    color:{tier_color};">{pop.tier}</div>
+        <div style="font-family:'JetBrains Mono',monospace;font-size:.6rem;
+                    color:var(--muted);margin-top:4px;">{listeners_fmt} listeners</div>
+      </div>
+      <div class="sig" style="flex:2;min-width:180px;padding:14px 16px;">
+        <div style="font-family:'Chakra Petch',monospace;font-size:.5rem;font-weight:600;
+                    letter-spacing:.18em;text-transform:uppercase;color:var(--dim);
+                    margin-bottom:6px;">Est. Sync Fee</div>
+        <div style="font-family:'Chakra Petch',monospace;font-size:.95rem;font-weight:700;
+                    color:var(--text);">{cost_fmt}</div>
+        <div style="font-family:'Figtree',sans-serif;font-size:.7rem;color:var(--muted);
+                    margin-top:4px;">Varies by usage, territory, and negotiation.
+                    Source: Last.fm · Industry estimates 2024–2026.</div>
+      </div>
+    </div>
+    """, unsafe_allow_html=True)
+
+
 def _render_legal_and_discovery(result: AnalysisResult) -> None:
+    _render_popularity_card(result)
+
+    st.markdown("""
+    <div style="font-family:'Chakra Petch',monospace;font-size:.58rem;font-weight:600;
+                letter-spacing:.18em;text-transform:uppercase;color:var(--dim);
+                display:flex;align-items:center;gap:10px;margin-bottom:14px;">
+      <span>◈ Rights Lookup</span>
+      <div style="flex:1;height:1px;background:var(--border-hr);"></div>
+    </div>
+    """, unsafe_allow_html=True)
+
     if result.legal:
         for name, url in [("ASCAP", result.legal.ascap), ("BMI", result.legal.bmi), ("SESAC", result.legal.sesac)]:
             if url:


### PR DESCRIPTION
Closes #31

## Changes
- **config.py**: POPULARITY_*_MIN and SYNC_COST_* thresholds in SystemConstants
- **models.py**: PopularityResult model + popularity field on AnalysisResult
- **discovery.py**: `get_track_popularity()` + pure `_classify_popularity()` with injectable constants
- **loading.py**: popularity fetched in legal step, passed to model_validate
- **report.py**: popularity card with tier badge + sync cost estimate; uses CSS vars from styles.py
- **test_discovery.py**: 6 unit tests for tier boundary conditions

## Review fixes applied
- Magic hex colors replaced with var(--issue-location), var(--grade-c), var(--accent)
- _classify_popularity made injectable for testing
- 225 tests pass