### PR TITLE
feat(legal): MusicBrainz PRO lookup — ISRC + PRO inference (#23)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -107,6 +107,10 @@ class SystemConstants:
     # ---- Discovery ------------------------------------------------------------
     MAX_SIMILAR_TRACKS: int = 5
 
+    # ---- MusicBrainz API --------------------------------------------------------
+    # Per-request HTTP timeout for MusicBrainz recordings API calls.
+    MB_TIMEOUT_S: int = 8
+
     # ---- Pipeline step timeout budgets (seconds) ------------------------------
     # Generous walls to prevent hung subprocesses (yt-dlp, Whisper, allin1)
     # from blocking the UI indefinitely on ZeroGPU.
@@ -663,6 +667,15 @@ class Settings(BaseSettings):
     hf_token: Optional[str] = Field(
         default=None,
         description="HuggingFace token for private model access (optional).",
+    )
+
+    # ---- MusicBrainz API (PRO lookup) -----------------------------------------
+    # MusicBrainz requires a descriptive User-Agent for all API requests.
+    # Format: "AppName/Version (contact_url_or_email)"
+    musicbrainz_app: str = Field(
+        default="sync-safe-forensic-portal/1.0 (https://github.com/borrvick/sync-safe)",
+        description="User-Agent string sent to MusicBrainz API. "
+                    "Set to your app name, version, and contact URL/email.",
     )
 
     # ---- Model selection ------------------------------------------------------

--- a/core/models.py
+++ b/core/models.py
@@ -346,13 +346,17 @@ class TrackCandidate(BaseModel):
 
 
 class LegalLinks(BaseModel):
-    """PRO repertory search URLs for a given track."""
+    """PRO repertory search URLs and inferred PRO match for a given track."""
 
     model_config = ConfigDict(frozen=True)
 
     ascap: str  = ""
     bmi: str    = ""
     sesac: str  = ""
+
+    # Populated by services/pro_lookup.py — None when MusicBrainz returns no hit
+    isrc: Optional[str]      = None  # e.g. "US-ABC-23-12345"
+    pro_match: Optional[str] = None  # e.g. "ASCAP/BMI (US)", "PRS (UK)"
 
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump()

--- a/core/protocols.py
+++ b/core/protocols.py
@@ -22,6 +22,7 @@ Swap guide:
   AuthorshipAnalyzer → swap RoBERTa for GPTZero API or a fine-tuned model
   TrackDiscovery     → swap Last.fm for Spotify, Soundcharts, or internal DB
   LegalLinksProvider → swap static URL templates for a live licensing API
+  ProLookupProvider  → swap MusicBrainz for a paid metadata provider
 """
 from __future__ import annotations
 
@@ -307,5 +308,29 @@ class LegalLinksProvider(Protocol):
 
         Returns:
             LegalLinks with ASCAP, BMI, and SESAC search URLs.
+        """
+        ...
+
+
+class ProLookupProvider(Protocol):
+    """
+    Best-effort ISRC and PRO affiliation lookup from an external metadata source.
+
+    Implementations: services/pro_lookup.py (MusicBrainz recordings API)
+    Swap candidates:  Songkick, AcousticBrainz, or a paid licensing data provider.
+    """
+
+    def lookup(
+        self,
+        title: str,
+        artist: str,
+    ) -> tuple[Optional[str], Optional[str]]:
+        """
+        Args:
+            title:  Track title.
+            artist: Artist name.
+
+        Returns:
+            (isrc, pro_match) tuple — both None when no match found or on error.
         """
         ...

--- a/services/pro_lookup.py
+++ b/services/pro_lookup.py
@@ -1,0 +1,147 @@
+"""
+services/pro_lookup.py
+MusicBrainz-based PRO (Performing Rights Organisation) lookup.
+
+Queries the MusicBrainz recordings API to:
+1. Find a matching recording for a given title + artist.
+2. Extract the ISRC if available (sound recording identifier).
+3. Infer the likely PRO from the ISRC country prefix or recording area.
+
+Design notes:
+- ProLookup is stateless — instantiate per call.
+- _infer_pro and _parse_first_recording are pure functions for testability.
+- MusicBrainz requires a descriptive User-Agent; sourced from Settings.musicbrainz_app.
+- Rate limit: MusicBrainz allows max 1 req/s — caller (loading.py) is already
+  sequential; no explicit sleep required for single-call use.
+- Returns (None, None) on any network failure — PRO lookup is best-effort.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from urllib.parse import urlencode
+
+import requests
+
+from core.config import CONSTANTS, get_settings
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# PRO inference table — ISO-3166-1 alpha-2 country codes → PRO name
+# ---------------------------------------------------------------------------
+
+_COUNTRY_PRO_MAP: dict[str, str] = {
+    "US": "ASCAP / BMI / SESAC (US)",
+    "GB": "PRS for Music (UK)",
+    "DE": "GEMA (Germany)",
+    "FR": "SACEM (France)",
+    "CA": "SOCAN (Canada)",
+    "AU": "APRA AMCOS (Australia)",
+    "SE": "STIM (Sweden)",
+    "NO": "TONO (Norway)",
+    "DK": "KODA (Denmark)",
+    "FI": "Teosto (Finland)",
+    "NL": "Buma/Stemra (Netherlands)",
+    "BE": "SABAM (Belgium)",
+    "IT": "SIAE (Italy)",
+    "ES": "SGAE (Spain)",
+    "BR": "ECAD (Brazil)",
+    "JP": "JASRAC (Japan)",
+    "KR": "KOMCA (South Korea)",
+    "MX": "SACM (Mexico)",
+}
+
+_MB_API_BASE = "https://musicbrainz.org/ws/2"
+
+
+class ProLookup:
+    """
+    Queries MusicBrainz to infer ISRC and PRO for a given track.
+
+    Usage:
+        isrc, pro = ProLookup().lookup("Blinding Lights", "The Weeknd")
+    """
+
+    def lookup(self, title: str, artist: str) -> tuple[Optional[str], Optional[str]]:
+        """
+        Look up ISRC and inferred PRO affiliation via MusicBrainz.
+
+        Args:
+            title:  Track title.
+            artist: Artist name.
+
+        Returns:
+            (isrc, pro_match) — both None if no confident match found or on error.
+            This method never raises — PRO lookup is best-effort.
+        """
+        if not title.strip() or not artist.strip():
+            return None, None
+
+        settings = get_settings()
+        headers  = {"User-Agent": settings.musicbrainz_app}
+
+        # urlencode handles quoting of the full query value (including the Lucene
+        # quotes and spaces). inc uses '+' as MB's documented separator — appended
+        # outside urlencode so the '+' is not percent-encoded to '%2B'.
+        query_str = f'recording:"{title.strip()}" AND artist:"{artist.strip()}"'
+        params    = urlencode({"query": query_str, "fmt": "json", "limit": "3"})
+        url       = f"{_MB_API_BASE}/recording/?{params}&inc=isrcs+releases"
+
+        try:
+            resp = requests.get(url, headers=headers, timeout=CONSTANTS.MB_TIMEOUT_S)
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as exc:
+            # Network failures are non-fatal — log and return empty result
+            _log.warning("ProLookup: MusicBrainz request failed: %s", exc)
+            return None, None
+
+        return _parse_first_recording(data)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def _parse_first_recording(
+    data: dict,
+) -> tuple[Optional[str], Optional[str]]:
+    """
+    Extract ISRC and infer PRO from the first MusicBrainz recording result.
+
+    Pure function — no I/O.
+    """
+    recordings: list[dict] = data.get("recordings", [])
+    if not recordings:
+        return None, None
+
+    first = recordings[0]
+
+    # ISRC — list[str]; take the first if present
+    isrcs: list[str] = first.get("isrcs", [])
+    isrc = isrcs[0] if isrcs else None
+
+    # Infer PRO from ISRC country prefix (first 2 chars of ISRC = country)
+    pro: Optional[str] = None
+    if isrc and len(isrc) >= 2:
+        country_code = isrc[:2].upper()
+        pro = _infer_pro(country_code)
+
+    return isrc, pro
+
+
+def _infer_pro(country_code: str) -> Optional[str]:
+    """
+    Map an ISO-3166-1 alpha-2 country code to a PRO name string.
+
+    Pure function — no I/O.
+
+    Args:
+        country_code: Two-letter uppercase country code (e.g. "US", "GB").
+
+    Returns:
+        Human-readable PRO name, or None if country is not in the lookup table.
+    """
+    return _COUNTRY_PRO_MAP.get(country_code.upper())

--- a/tests/test_pro_lookup.py
+++ b/tests/test_pro_lookup.py
@@ -1,0 +1,78 @@
+"""
+tests/test_pro_lookup.py
+Unit tests for services/pro_lookup.py — pure helper functions only.
+ProLookup.lookup() makes a network call and is tested manually.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.pro_lookup import _infer_pro, _parse_first_recording
+
+
+# ---------------------------------------------------------------------------
+# _infer_pro
+# ---------------------------------------------------------------------------
+
+class TestInferPro:
+    def test_us_returns_combined_label(self) -> None:
+        assert _infer_pro("US") == "ASCAP / BMI / SESAC (US)"
+
+    def test_gb_returns_prs(self) -> None:
+        assert _infer_pro("GB") == "PRS for Music (UK)"
+
+    def test_de_returns_gema(self) -> None:
+        assert _infer_pro("DE") == "GEMA (Germany)"
+
+    def test_unknown_country_returns_none(self) -> None:
+        assert _infer_pro("ZZ") is None
+
+    def test_lowercase_input_normalised(self) -> None:
+        assert _infer_pro("us") == "ASCAP / BMI / SESAC (US)"
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _infer_pro("") is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_first_recording
+# ---------------------------------------------------------------------------
+
+class TestParseFirstRecording:
+    def test_empty_recordings_returns_none_tuple(self) -> None:
+        assert _parse_first_recording({}) == (None, None)
+        assert _parse_first_recording({"recordings": []}) == (None, None)
+
+    def test_isrc_extracted_from_first_recording(self) -> None:
+        data = {"recordings": [{"isrcs": ["US-ABC-23-12345"]}]}
+        isrc, _ = _parse_first_recording(data)
+        assert isrc == "US-ABC-23-12345"
+
+    def test_pro_inferred_from_isrc_country(self) -> None:
+        data = {"recordings": [{"isrcs": ["GB-XYZ-23-99999"]}]}
+        _, pro = _parse_first_recording(data)
+        assert pro == "PRS for Music (UK)"
+
+    def test_no_isrcs_returns_none_for_both(self) -> None:
+        data = {"recordings": [{"isrcs": []}]}
+        isrc, pro = _parse_first_recording(data)
+        assert isrc is None
+        assert pro is None
+
+    def test_unknown_country_isrc_returns_none_pro(self) -> None:
+        data = {"recordings": [{"isrcs": ["ZZ-ABC-23-12345"]}]}
+        isrc, pro = _parse_first_recording(data)
+        assert isrc == "ZZ-ABC-23-12345"
+        assert pro is None
+
+    def test_second_recording_ignored(self) -> None:
+        """Only the first result should be used."""
+        data = {
+            "recordings": [
+                {"isrcs": ["US-AAA-23-00001"]},
+                {"isrcs": ["GB-BBB-23-00002"]},
+            ]
+        }
+        isrc, pro = _parse_first_recording(data)
+        assert isrc == "US-AAA-23-00001"
+        assert pro == "ASCAP / BMI / SESAC (US)"

--- a/ui/pages/loading.py
+++ b/ui/pages/loading.py
@@ -612,7 +612,10 @@ def render_loading(source: Any) -> None:
             from services.discovery import Discovery
             from services.legal import Legal
             from services.loudness import AudioQualityAnalyzer
-            legal         = Legal().get_links(title, artist)
+            from services.pro_lookup import ProLookup
+            base_links    = Legal().get_links(title, artist)
+            isrc, pro     = ProLookup().lookup(title, artist)
+            legal         = base_links.model_copy(update={"isrc": isrc, "pro_match": pro})
             popularity    = Discovery().get_track_popularity(title, artist)
             audio_quality = AudioQualityAnalyzer().analyze(audio)
     except StepTimeoutError as exc:

--- a/ui/pages/report.py
+++ b/ui/pages/report.py
@@ -889,6 +889,27 @@ def _render_legal_and_discovery(result: AnalysisResult) -> None:
     """, unsafe_allow_html=True)
 
     if result.legal:
+        # ISRC + inferred PRO badge (only shown when MusicBrainz returned a hit)
+        if result.legal.isrc or result.legal.pro_match:
+            isrc_text = html_mod.escape(result.legal.isrc or "—")
+            pro_text  = html_mod.escape(result.legal.pro_match or "Unknown")
+            st.markdown(f"""
+            <div class="sig" style="padding:14px 18px;margin-bottom:12px;display:flex;
+                         flex-wrap:wrap;gap:18px;align-items:center;">
+              <div>
+                <div style="font-size:.58rem;font-weight:600;letter-spacing:.14em;
+                            text-transform:uppercase;color:var(--dim);margin-bottom:4px;">ISRC</div>
+                <div style="font-family:'Chakra Petch',monospace;font-size:.9rem;
+                            color:var(--text);">{isrc_text}</div>
+              </div>
+              <div>
+                <div style="font-size:.58rem;font-weight:600;letter-spacing:.14em;
+                            text-transform:uppercase;color:var(--dim);margin-bottom:4px;">Inferred PRO</div>
+                <div style="font-family:'Chakra Petch',monospace;font-size:.9rem;
+                            color:var(--accent);">{pro_text}</div>
+              </div>
+            </div>""", unsafe_allow_html=True)
+
         for name, url in [("ASCAP", result.legal.ascap), ("BMI", result.legal.bmi), ("SESAC", result.legal.sesac)]:
             if url:
                 st.link_button(f"Search {name} →", url, use_container_width=True)


### PR DESCRIPTION
## Summary
- Adds `services/pro_lookup.py` — `ProLookup` queries MusicBrainz recordings API to extract ISRC and infer PRO affiliation from the ISRC country prefix (18 PROs mapped)
- `LegalLinks` model extended with `isrc: Optional[str]` and `pro_match: Optional[str]`
- Report shows ISRC + Inferred PRO badge in the Rights Lookup card when a match is found
- `ProLookupProvider` protocol added to `core/protocols.py`
- Network failures are best-effort (returns `(None, None)`) — never blocks the legal step
- `MB_TIMEOUT_S` constant in `SystemConstants`; User-Agent configurable via `Settings.musicbrainz_app`

## Test plan
- [x] `pytest tests/test_pro_lookup.py` — 12/12 pass
- [ ] Manual smoke: submit a well-known track and verify ISRC badge renders in Rights Lookup
- [ ] Manual: submit an obscure/instrumental track and verify card is hidden when MB returns no hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)