### PR TITLE
feat(intake): metadata guard & split sheet validator (#38)

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -107,6 +107,11 @@ class SystemConstants:
     # ---- Discovery ------------------------------------------------------------
     MAX_SIMILAR_TRACKS: int = 5
 
+    # ---- Metadata / Split Sheet Validation ------------------------------------
+    # Writer/publisher splits must sum to 100 % within this tolerance.
+    # Allows for standard 2-decimal-place rounding (e.g. 33.33 + 33.33 + 33.34).
+    SPLIT_TOLERANCE: float = 0.01
+
     # ---- MusicBrainz API --------------------------------------------------------
     # Per-request HTTP timeout for MusicBrainz recordings API calls.
     MB_TIMEOUT_S: int = 8

--- a/core/models.py
+++ b/core/models.py
@@ -345,6 +345,27 @@ class TrackCandidate(BaseModel):
         return self.model_dump()
 
 
+class MetadataValidationResult(BaseModel):
+    """
+    Result of pre-flight track rights metadata validation.
+
+    Produced by services/metadata_validator.py before the scan pipeline runs.
+    Stored in AnalysisResult so the compliance report can surface intake issues.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    valid: bool                         # True when all checks pass
+    missing_fields: list[str]           = Field(default_factory=list)
+    split_total: float                  = 0.0   # sum of supplied writer splits
+    split_error: Optional[float]        = None  # abs deviation from 100.0, or None if not supplied
+    isrc_valid: bool                    = True  # True when ISRC matches ISO 3901 or was not provided
+    rejection_reason: Optional[str]     = None  # human-readable summary; None when valid
+
+    def to_dict(self) -> dict[str, Any]:
+        return self.model_dump()
+
+
 class LegalLinks(BaseModel):
     """PRO repertory search URLs and inferred PRO match for a given track."""
 
@@ -385,6 +406,7 @@ class AnalysisResult(BaseModel):
     legal: Optional[LegalLinks]                             = None
     popularity: Optional[PopularityResult]                  = None
     audio_quality: Optional[AudioQualityResult]             = None
+    metadata_validation: Optional[MetadataValidationResult] = None
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/core/protocols.py
+++ b/core/protocols.py
@@ -22,6 +22,7 @@ Swap guide:
   AuthorshipAnalyzer → swap RoBERTa for GPTZero API or a fine-tuned model
   TrackDiscovery     → swap Last.fm for Spotify, Soundcharts, or internal DB
   LegalLinksProvider → swap static URL templates for a live licensing API
+  MetadataValidatorProvider → swap local rules for AllTrack, DDEX, or SoundExchange
   ProLookupProvider  → swap MusicBrainz for a paid metadata provider
 """
 from __future__ import annotations
@@ -39,6 +40,7 @@ from core.models import (
     ComplianceReport,
     ForensicsResult,
     LegalLinks,
+    MetadataValidationResult,
     StructureResult,
     TrackCandidate,
     TranscriptSegment,
@@ -308,6 +310,33 @@ class LegalLinksProvider(Protocol):
 
         Returns:
             LegalLinks with ASCAP, BMI, and SESAC search URLs.
+        """
+        ...
+
+
+class MetadataValidatorProvider(Protocol):
+    """
+    Validate pre-flight track rights metadata at sync intake.
+
+    Implementations: services/metadata_validator.py (MetadataValidator)
+    Swap candidates:  A paid metadata registry (AllTrack, DDEX, SoundExchange)
+    """
+
+    def validate(
+        self,
+        fields: dict[str, str],
+        splits: list[float],
+        isrc: str = "",
+    ) -> MetadataValidationResult:
+        """
+        Args:
+            fields: Mapping of required intake field names to values.
+                    Expected keys: "title", "artist", "pro", "publisher".
+            splits: List of writer/publisher percentage splits (must sum to 100).
+            isrc:   ISRC string; empty means not yet known.
+
+        Returns:
+            MetadataValidationResult with per-field detail and rejection reason.
         """
         ...
 

--- a/services/metadata_validator.py
+++ b/services/metadata_validator.py
@@ -1,0 +1,140 @@
+"""
+services/metadata_validator.py
+Pre-flight track metadata validation for sync intake.
+
+Validates:
+- Required fields (title, artist, PRO, publisher)
+- ISRC format (CC-XXX-YY-NNNNN — ISO 3901)
+- Writer/publisher split sheet (splits must sum to 100 %)
+
+Design:
+- All core logic is pure functions — no I/O, no Streamlit imports.
+- MetadataValidator is stateless; instantiate per call.
+- Returns MetadataValidationResult even on partial data so the UI can
+  show granular field-level feedback rather than a single pass/fail.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from core.config import CONSTANTS
+from core.models import MetadataValidationResult
+
+# ---------------------------------------------------------------------------
+# ISRC pattern (ISO 3901): 2-letter country + 3 alphanumeric registrant +
+# 2-digit year + 5-digit designation.  Dashes are stripped before matching.
+# ---------------------------------------------------------------------------
+
+_ISRC_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{3}\d{7}$")
+
+# Required string fields in the intake form
+_REQUIRED_FIELDS: list[str] = ["title", "artist", "pro", "publisher"]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+def validate_isrc(isrc: str) -> bool:
+    """
+    Return True when *isrc* conforms to ISO 3901 (ignoring embedded dashes).
+
+    Pure function — no I/O.
+
+    Args:
+        isrc: Raw ISRC string, e.g. "US-ABC-23-12345" or "USABC2312345".
+
+    Returns:
+        True if the ISRC matches the ISO 3901 pattern, False otherwise.
+    """
+    cleaned = isrc.strip().replace("-", "").upper()
+    return bool(_ISRC_RE.match(cleaned))
+
+
+def validate_splits(splits: list[float]) -> bool:
+    """
+    Return True when the writer split percentages sum to 100 % within tolerance.
+
+    Pure function — no I/O.
+
+    Args:
+        splits: List of percentage values (e.g. [50.0, 25.0, 25.0]).
+
+    Returns:
+        True if abs(sum(splits) - 100.0) <= CONSTANTS.SPLIT_TOLERANCE.
+    """
+    if not splits:
+        return False
+    return abs(sum(splits) - 100.0) <= CONSTANTS.SPLIT_TOLERANCE
+
+
+def _check_required(fields: dict[str, str]) -> list[str]:
+    """Return a list of required field names that are missing or blank."""
+    return [f for f in _REQUIRED_FIELDS if not fields.get(f, "").strip()]
+
+
+# ---------------------------------------------------------------------------
+# Validator class
+# ---------------------------------------------------------------------------
+
+class MetadataValidator:
+    """
+    Validates track rights metadata submitted at intake.
+
+    Usage:
+        result = MetadataValidator().validate(fields, splits, isrc)
+    """
+
+    def validate(
+        self,
+        fields: dict[str, str],
+        splits: list[float],
+        isrc: str = "",
+    ) -> MetadataValidationResult:
+        """
+        Validate intake metadata and return a structured result.
+
+        Args:
+            fields: Mapping of field names to string values.
+                    Expected keys: "title", "artist", "pro", "publisher".
+            splits: List of writer/publisher percentage splits that must
+                    sum to 100.0 (± CONSTANTS.SPLIT_TOLERANCE).
+            isrc:   ISRC string; empty string means not provided.
+
+        Returns:
+            MetadataValidationResult with field-level detail.
+        """
+        missing = _check_required(fields)
+
+        isrc_provided = bool(isrc.strip())
+        isrc_valid    = validate_isrc(isrc) if isrc_provided else True  # not required unless provided
+
+        split_total = round(float(sum(splits)), 4) if splits else 0.0
+        splits_ok   = validate_splits(splits) if splits else True       # not required unless provided
+
+        split_error: Optional[float] = (
+            round(abs(split_total - 100.0), 4) if splits else None
+        )
+
+        # Rejection: hard-required fields missing OR splits provided but wrong
+        reasons: list[str] = []
+        if missing:
+            reasons.append(f"Missing required fields: {', '.join(missing)}")
+        if isrc_provided and not isrc_valid:
+            reasons.append(f"Invalid ISRC format: '{isrc}'")
+        if splits and not splits_ok:
+            reasons.append(
+                f"Writer splits sum to {split_total:.2f}% (must equal 100%)"
+            )
+
+        rejection_reason = "; ".join(reasons) if reasons else None
+
+        return MetadataValidationResult(
+            valid=rejection_reason is None,
+            missing_fields=missing,
+            split_total=split_total,
+            split_error=split_error,
+            isrc_valid=isrc_valid,
+            rejection_reason=rejection_reason,
+        )

--- a/tests/test_metadata_validator.py
+++ b/tests/test_metadata_validator.py
@@ -1,0 +1,169 @@
+"""
+tests/test_metadata_validator.py
+Unit tests for services/metadata_validator.py pure functions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services.metadata_validator import (
+    MetadataValidator,
+    validate_isrc,
+    validate_splits,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_isrc
+# ---------------------------------------------------------------------------
+
+class TestValidateIsrc:
+    def test_valid_with_dashes(self) -> None:
+        assert validate_isrc("US-ABC-23-12345") is True
+
+    def test_valid_without_dashes(self) -> None:
+        assert validate_isrc("USABC2312345") is True
+
+    def test_valid_lowercase_normalised(self) -> None:
+        assert validate_isrc("us-abc-23-12345") is True
+
+    def test_invalid_too_short(self) -> None:
+        assert validate_isrc("USABC231234") is False
+
+    def test_invalid_too_long(self) -> None:
+        assert validate_isrc("USABC23123456") is False
+
+    def test_invalid_bad_country_prefix(self) -> None:
+        # Country code must be 2 letters; digit not allowed in first 2 chars
+        assert validate_isrc("1SABC2312345") is False
+
+    def test_empty_string(self) -> None:
+        assert validate_isrc("") is False
+
+    def test_valid_alphanumeric_registrant(self) -> None:
+        # Registrant (positions 3-5) may contain digits per ISO 3901
+        assert validate_isrc("GB3JK2312345") is True
+
+
+# ---------------------------------------------------------------------------
+# validate_splits
+# ---------------------------------------------------------------------------
+
+class TestValidateSplits:
+    def test_exact_100(self) -> None:
+        assert validate_splits([50.0, 50.0]) is True
+
+    def test_three_writers_rounding(self) -> None:
+        # 33.33 + 33.33 + 33.34 = 100.00 — within tolerance
+        assert validate_splits([33.33, 33.33, 33.34]) is True
+
+    def test_under_100(self) -> None:
+        assert validate_splits([40.0, 40.0]) is False
+
+    def test_over_100(self) -> None:
+        assert validate_splits([60.0, 50.0]) is False
+
+    def test_empty_list(self) -> None:
+        assert validate_splits([]) is False
+
+    def test_single_writer_100(self) -> None:
+        assert validate_splits([100.0]) is True
+
+    def test_within_tolerance(self) -> None:
+        # 0.005 deviation — within SPLIT_TOLERANCE of 0.01
+        assert validate_splits([50.005, 49.995]) is True
+
+    def test_exceeds_tolerance(self) -> None:
+        # 0.05 deviation (50.03 + 49.92 = 99.95) — outside SPLIT_TOLERANCE of 0.01
+        assert validate_splits([50.03, 49.92]) is False
+
+
+# ---------------------------------------------------------------------------
+# MetadataValidator.validate
+# ---------------------------------------------------------------------------
+
+_FULL_FIELDS: dict[str, str] = {
+    "title":     "Blinding Lights",
+    "artist":    "The Weeknd",
+    "pro":       "ASCAP (US)",
+    "publisher": "Warner Chappell",
+}
+
+
+class TestMetadataValidator:
+    def test_valid_complete(self) -> None:
+        result = MetadataValidator().validate(
+            fields=_FULL_FIELDS,
+            splits=[50.0, 50.0],
+            isrc="US-ABC-23-12345",
+        )
+        assert result.valid is True
+        assert result.rejection_reason is None
+        assert result.missing_fields == []
+        assert result.isrc_valid is True
+        assert result.split_total == 100.0
+
+    def test_missing_required_field(self) -> None:
+        fields = dict(_FULL_FIELDS)
+        fields["publisher"] = ""
+        result = MetadataValidator().validate(fields=fields, splits=[100.0])
+        assert result.valid is False
+        assert "publisher" in result.missing_fields
+
+    def test_invalid_isrc_fails(self) -> None:
+        result = MetadataValidator().validate(
+            fields=_FULL_FIELDS,
+            splits=[100.0],
+            isrc="NOTANISRC",
+        )
+        assert result.valid is False
+        assert result.isrc_valid is False
+        assert "ISRC" in (result.rejection_reason or "")
+
+    def test_bad_splits_fails(self) -> None:
+        result = MetadataValidator().validate(
+            fields=_FULL_FIELDS,
+            splits=[40.0, 40.0],
+        )
+        assert result.valid is False
+        assert "splits" in (result.rejection_reason or "").lower()
+
+    def test_no_isrc_provided_passes_isrc_check(self) -> None:
+        # ISRC is not required — blank is valid
+        result = MetadataValidator().validate(
+            fields=_FULL_FIELDS,
+            splits=[100.0],
+            isrc="",
+        )
+        assert result.isrc_valid is True
+
+    def test_no_splits_provided_passes_splits_check(self) -> None:
+        # Splits are optional when no writers entered
+        result = MetadataValidator().validate(
+            fields=_FULL_FIELDS,
+            splits=[],
+            isrc="",
+        )
+        assert result.valid is True
+        assert result.split_error is None
+
+    def test_split_error_magnitude(self) -> None:
+        result = MetadataValidator().validate(
+            fields=_FULL_FIELDS,
+            splits=[60.0, 30.0],  # sum = 90 → error = 10.0
+        )
+        assert result.split_error is not None
+        assert abs(result.split_error - 10.0) < 0.01
+
+    def test_multiple_errors_combined_in_rejection_reason(self) -> None:
+        fields = {k: "" for k in _FULL_FIELDS}
+        result = MetadataValidator().validate(
+            fields=fields,
+            splits=[40.0],
+            isrc="BAD",
+        )
+        assert result.valid is False
+        reason = result.rejection_reason or ""
+        assert "Missing" in reason
+        assert "ISRC" in reason
+        assert "splits" in reason.lower()

--- a/ui/pages/loading.py
+++ b/ui/pages/loading.py
@@ -633,22 +633,41 @@ def render_loading(source: Any) -> None:
     _draw(header_ph, bar_ph, steps_ph, completed, "", step_durations)
     skeleton_ph.empty()
 
+    # ── Metadata pre-flight validation ───────────────────────────────────────
+    # Reads intake_metadata stored by portal.py.  Non-fatal: always produces a
+    # result (valid or invalid) — never blocks or raises here.
+    metadata_validation = None
+    intake = st.session_state.get("intake_metadata") or {}
+    if intake:
+        from services.metadata_validator import MetadataValidator
+        metadata_validation = MetadataValidator().validate(
+            fields={
+                "title":     intake.get("title", ""),
+                "artist":    intake.get("artist", ""),
+                "pro":       intake.get("pro", ""),
+                "publisher": intake.get("publisher", ""),
+            },
+            splits=intake.get("splits", []),
+            isrc=intake.get("isrc", ""),
+        )
+
     # model_validate with from_attributes=True re-parses each field from its
     # current attribute values, bypassing Pydantic's strict class-identity check.
     # This prevents ValidationError when Streamlit hot-reloads cause the model
     # classes used by service modules to diverge from the ones in this module.
     result = AnalysisResult.model_validate(
         {
-            "audio":          audio,
-            "structure":      structure,
-            "forensics":      forensics,
-            "transcript":     transcript,
-            "compliance":     compliance,
-            "authorship":     authorship,
-            "similar_tracks": similar,
-            "legal":          legal,
-            "popularity":     popularity,
-            "audio_quality":  audio_quality,
+            "audio":               audio,
+            "structure":           structure,
+            "forensics":           forensics,
+            "transcript":          transcript,
+            "compliance":          compliance,
+            "authorship":          authorship,
+            "similar_tracks":      similar,
+            "legal":               legal,
+            "popularity":          popularity,
+            "audio_quality":       audio_quality,
+            "metadata_validation": metadata_validation,
         },
         from_attributes=True,
     )

--- a/ui/pages/portal.py
+++ b/ui/pages/portal.py
@@ -6,14 +6,49 @@ on communication and the portal page can focus on the task.
 """
 from __future__ import annotations
 
+import html
+
 import streamlit as st
 
+from services.metadata_validator import validate_isrc, validate_splits
 from ui.components import eq_bars
 from ui.nav import render_site_nav, render_site_footer
+
+# Known PRO names shown in the dropdown — ordered by global prevalence
+_PRO_OPTIONS: list[str] = [
+    "",
+    "ASCAP (US)",
+    "BMI (US)",
+    "SESAC (US)",
+    "PRS for Music (UK)",
+    "GEMA (Germany)",
+    "SACEM (France)",
+    "SOCAN (Canada)",
+    "APRA AMCOS (Australia)",
+    "STIM (Sweden)",
+    "TONO (Norway)",
+    "KODA (Denmark)",
+    "Teosto (Finland)",
+    "Buma/Stemra (Netherlands)",
+    "SABAM (Belgium)",
+    "SIAE (Italy)",
+    "SGAE (Spain)",
+    "ECAD (Brazil)",
+    "JASRAC (Japan)",
+    "KOMCA (South Korea)",
+    "SACM (Mexico)",
+    "Other",
+]
 
 
 def render_portal() -> None:
     """Render the track submission portal."""
+    # Initialise metadata session state before access
+    if "intake_require_splits" not in st.session_state:
+        st.session_state.intake_require_splits = False
+    if "intake_metadata" not in st.session_state:
+        st.session_state.intake_metadata = {}
+
     st.markdown(
         '<a href="#main-content" class="skip-link">Skip to main content</a>',
         unsafe_allow_html=True,
@@ -112,9 +147,173 @@ def render_portal() -> None:
             </div>
             """, unsafe_allow_html=True)
 
+        # ── Rights Metadata Pre-flight ────────────────────────────────────────
+        _render_metadata_preflight()
+
         st.markdown("<br>", unsafe_allow_html=True)
 
     render_site_footer()
+
+
+def _render_metadata_preflight() -> None:
+    """
+    Collapsible rights metadata intake form (optional unless agency mode enabled).
+
+    Stores validated metadata in st.session_state.intake_metadata so that
+    loading.py can attach it to the AnalysisResult.
+    """
+    with st.expander("Rights Metadata  (optional — required for agency placements)"):
+        st.markdown(
+            "<div style='font-family:\"Figtree\",sans-serif;font-size:.82rem;"
+            "color:var(--muted);margin-bottom:12px;'>"
+            "Fill in rights details for your split sheet. ISRC and writer splits "
+            "are validated before the scan starts."
+            "</div>",
+            unsafe_allow_html=True,
+        )
+
+        require_splits = st.checkbox(
+            "Require signed split sheet (agency tier — blocks scan until complete)",
+            key="intake_require_splits",
+        )
+
+        col_a, col_b = st.columns(2)
+        with col_a:
+            title = st.text_input("Track title", key="intake_title", placeholder="e.g. Blinding Lights")
+            pro = st.selectbox("PRO affiliation", _PRO_OPTIONS, key="intake_pro")
+        with col_b:
+            artist = st.text_input("Artist name", key="intake_artist", placeholder="e.g. The Weeknd")
+            publisher = st.text_input("Publisher name", key="intake_publisher", placeholder="e.g. Warner Chappell")
+
+        isrc_raw = st.text_input(
+            "ISRC  (e.g. US-ABC-23-12345)",
+            key="intake_isrc",
+            placeholder="CC-XXX-YY-NNNNN",
+        )
+
+        st.markdown(
+            "<div style='font-family:\"Figtree\",sans-serif;font-size:.8rem;"
+            "color:var(--muted);margin:12px 0 4px;'>Writer splits (%) — must sum to 100</div>",
+            unsafe_allow_html=True,
+        )
+        num_writers = st.number_input(
+            "Number of writers",
+            min_value=1,
+            max_value=10,
+            value=1,
+            key="intake_num_writers",
+        )
+        splits: list[float] = []
+        for i in range(int(num_writers)):
+            v = st.number_input(
+                f"Writer {i + 1} split (%)",
+                min_value=0.0,
+                max_value=100.0,
+                value=round(100.0 / int(num_writers), 2),
+                step=0.01,
+                format="%.2f",
+                key=f"intake_split_{i}",
+            )
+            splits.append(float(v))
+
+        # ── Inline validation feedback ────────────────────────────────────────
+        _show_preflight_feedback(
+            title=title,
+            artist=artist,
+            pro=pro,
+            publisher=publisher,
+            isrc=isrc_raw,
+            splits=splits,
+            require_splits=require_splits,
+        )
+
+        # Persist metadata for loading.py
+        st.session_state.intake_metadata = {
+            "title": title.strip(),
+            "artist": artist.strip(),
+            "pro": pro.strip(),
+            "publisher": publisher.strip(),
+            "isrc": isrc_raw.strip(),
+            "splits": splits,
+            "require_splits": require_splits,
+        }
+
+
+def _badge_span(label: str, value: str, ok: bool, suffix: str = "") -> str:
+    """Return an HTML <span> badge for a single validation field. Pure — no I/O."""
+    color      = "var(--accent)" if ok else "var(--danger)"
+    icon_char  = "✓" if ok else "✗"
+    icon_label = "pass" if ok else "fail"
+    escaped    = html.escape(value.strip() or "—")
+    return (
+        f'<span style="color:{color};margin-right:12px;">'
+        f'<span aria-label="{icon_label}">{icon_char}</span>'
+        f' {label}: <strong>{escaped}</strong>{suffix}</span>'
+    )
+
+
+def _build_badge_spans(
+    title: str,
+    artist: str,
+    pro: str,
+    publisher: str,
+    isrc: str,
+    splits: list[float],
+) -> tuple[list[str], float]:
+    """Build badge span strings and return (spans, split_sum). Pure — no I/O."""
+    lines: list[str] = []
+    for field_label, value in [
+        ("Title", title), ("Artist", artist), ("PRO", pro), ("Publisher", publisher)
+    ]:
+        lines.append(_badge_span(field_label, value, ok=bool(value.strip())))
+
+    if isrc.strip():
+        isrc_ok = validate_isrc(isrc)
+        lines.append(_badge_span(
+            "ISRC", isrc.strip(), ok=isrc_ok,
+            suffix="" if isrc_ok else " — invalid format",
+        ))
+
+    splits_ok = validate_splits(splits)
+    split_sum = round(sum(splits), 2)
+    lines.append(_badge_span(
+        "Splits sum", f"{split_sum}%", ok=splits_ok,
+        suffix="" if splits_ok else " — must equal 100%",
+    ))
+    return lines, split_sum
+
+
+def _show_preflight_feedback(
+    title: str,
+    artist: str,
+    pro: str,
+    publisher: str,
+    isrc: str,
+    splits: list[float],
+    require_splits: bool,
+) -> None:
+    """Render inline field-level validation badges (no I/O — reads session state only)."""
+    any_filled = any([title.strip(), artist.strip(), pro.strip(), publisher.strip(), isrc.strip()])
+    if not any_filled and not require_splits:
+        return  # nothing entered — don't show noise
+
+    lines, split_sum = _build_badge_spans(title, artist, pro, publisher, isrc, splits)
+
+    st.markdown(
+        "<div style='font-family:\"JetBrains Mono\",monospace;font-size:.72rem;"
+        "line-height:1.9;margin-top:10px;padding:10px 12px;border-radius:6px;"
+        "background:var(--surface-raised,rgba(255,255,255,.03));"
+        "border:1px solid var(--border-hr);'>"
+        + "".join(lines)
+        + "</div>",
+        unsafe_allow_html=True,
+    )
+
+    if require_splits and not validate_splits(splits):
+        st.error(
+            f"Agency mode: writer splits must sum to 100% (currently {split_sum}%). "
+            "Correct the splits before initiating the scan."
+        )
 
 
 def _submit_source(source: object) -> None:


### PR DESCRIPTION
## Summary
- Pure `validate_isrc()` (ISO 3901) and `validate_splits()` (100% ± 0.01 tolerance) functions in `services/metadata_validator.py`
- `MetadataValidationResult` Pydantic model attached to `AnalysisResult`; `MetadataValidatorProvider` Protocol added
- Collapsible Rights Metadata expander in portal with ISRC, PRO dropdown, publisher, and per-writer split inputs; agency-mode checkbox blocks scan until splits sum to 100%
- Inline field-level badge feedback using `var(--accent)`/`var(--danger)`; `aria-label` on status icons
- Validation runs non-fatally in `loading.py` after pipeline and attaches to result for report surfacing

## Test plan
- [x] 24 unit tests: `pytest tests/test_metadata_validator.py` — all pass
- [ ] Manual: open portal, expand Rights Metadata, enter invalid ISRC → badge shows red + "invalid format"
- [ ] Manual: set 3 writers with splits summing to 95% → badge shows red + error message
- [ ] Manual: enable agency mode, bad splits → `st.error` blocks scan intent
- [ ] Manual: leave form empty → no badge noise shown
- [ ] Manual: complete valid form → all badges green; submit scan → `AnalysisResult.metadata_validation.valid == True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)