### PR TITLE
feat(export): platform-aware catalog CSV for DISCO/Synchtank (#45)

### DIFF
--- a/core/protocols.py
+++ b/core/protocols.py
@@ -22,6 +22,7 @@ Swap guide:
   AuthorshipAnalyzer → swap RoBERTa for GPTZero API or a fine-tuned model
   TrackDiscovery     → swap Last.fm for Spotify, Soundcharts, or internal DB
   LegalLinksProvider → swap static URL templates for a live licensing API
+  PlatformExportProvider    → swap built-in CSV templates for a paid sync API (Songtradr, etc.)
   MetadataValidatorProvider → swap local rules for AllTrack, DDEX, or SoundExchange
   ProLookupProvider  → swap MusicBrainz for a paid metadata provider
 """
@@ -310,6 +311,29 @@ class LegalLinksProvider(Protocol):
 
         Returns:
             LegalLinks with ASCAP, BMI, and SESAC search URLs.
+        """
+        ...
+
+
+class PlatformExportProvider(Protocol):
+    """
+    Generate platform-specific catalog CSV bytes for a sync licensing portal.
+
+    Implementations: services/platform_export.py (to_platform_csv)
+    Swap candidates:  Songtradr API, Musicstax, or a custom DAM integration
+    """
+
+    def export(self, result: AnalysisResult, platform: str) -> bytes:
+        """
+        Args:
+            result:   Complete pipeline AnalysisResult.
+            platform: Target schema name (e.g. "generic", "disco", "synchtank").
+
+        Returns:
+            UTF-8-with-BOM CSV bytes ready for download or API upload.
+
+        Raises:
+            ValueError: if *platform* is not a recognised schema name.
         """
         ...
 

--- a/services/platform_export.py
+++ b/services/platform_export.py
@@ -1,0 +1,213 @@
+"""
+services/platform_export.py
+Platform-aware CSV export for sync licensing catalog imports.
+
+Generates single-track CSV rows mapped to the column schema expected by
+DISCO, Synchtank, and a generic platform-agnostic format.
+
+Supported platforms and their catalog import column schemas:
+- generic   — all Sync-Safe fields; useful for custom pipelines
+- disco     — DISCO catalog import (title, artist, bpm, key, isrc, tags, notes)
+- synchtank — Synchtank catalog manager CSV (track_title, artist_name, tempo,
+              key_signature, isrc_code, description)
+
+Design:
+- All functions are pure (no I/O, no Streamlit imports).
+- _extract_track_data is the single source of truth for data extraction.
+- _to_platform_row maps generic keys to platform column names and formats.
+- to_platform_csv is the public API — returns UTF-8-with-BOM bytes (Excel safe).
+"""
+from __future__ import annotations
+
+import csv
+import io
+
+from core.models import AnalysisResult
+
+# ---------------------------------------------------------------------------
+# Platform schema definitions
+# ---------------------------------------------------------------------------
+# Maps platform name → ordered list of CSV column names.
+# These match the documented import templates for each platform.
+
+PLATFORM_SCHEMAS: dict[str, list[str]] = {
+    "generic": [
+        "title", "artist", "bpm", "key", "isrc", "pro",
+        "ai_probability_pct", "verdict", "grade", "flags",
+        "sync_safe_cleared", "lufs_integrated",
+    ],
+    "disco": [
+        "title", "artist", "bpm", "key", "isrc", "tags", "notes",
+    ],
+    "synchtank": [
+        "track_title", "artist_name", "tempo", "key_signature",
+        "isrc_code", "description",
+    ],
+}
+
+# Verdict strings from ForensicsResult that indicate AI-generated content.
+# Used to compute SYNC_SAFE_CLEARED.
+_AI_VERDICTS: frozenset[str] = frozenset({"AI", "Likely AI"})
+
+
+# ---------------------------------------------------------------------------
+# Internal data extraction — pure, no I/O
+# ---------------------------------------------------------------------------
+
+def _extract_audio_fields(result: AnalysisResult) -> dict[str, str]:
+    """Extract title, artist, BPM, key, ISRC, PRO, and LUFS. Pure — no I/O."""
+    title  = result.audio.metadata.get("title", "") or result.audio.label or ""
+    artist = result.audio.metadata.get("artist", "") or ""
+    bpm = ""
+    key = ""
+    if result.structure:
+        bpm = str(round(float(result.structure.bpm), 1)) if isinstance(result.structure.bpm, (int, float)) else ""
+        key = result.structure.key or ""
+    isrc = (result.legal.isrc or "") if result.legal else ""
+    pro  = (result.legal.pro_match or "") if result.legal else ""
+    lufs = str(result.audio_quality.integrated_lufs) if result.audio_quality else ""
+    return {"title": title, "artist": artist, "bpm": bpm, "key": key,
+            "isrc": isrc, "pro": pro, "lufs_integrated": lufs}
+
+
+def _extract_verdict_fields(result: AnalysisResult) -> dict[str, str]:
+    """Extract AI probability, verdict, grade, flags, and cleared status. Pure — no I/O."""
+    ai_prob = ""
+    verdict = ""
+    if result.forensics:
+        ai_prob = str(round(result.forensics.ai_probability * 100.0, 1))
+        verdict = result.forensics.verdict
+
+    grade      = (result.compliance.grade or "") if result.compliance else ""
+    flag_types = sorted({f.issue_type for f in result.compliance.flags}) if result.compliance else []
+    cleared    = (
+        grade in ("A", "B")
+        and not (result.compliance and result.compliance.hard_flags)
+        and verdict not in _AI_VERDICTS
+    )
+    return {
+        "ai_probability_pct": ai_prob,
+        "verdict":            verdict,
+        "grade":              grade,
+        "flags":              " | ".join(flag_types) if flag_types else "none",
+        "sync_safe_cleared":  "true" if cleared else "false",
+    }
+
+
+def _extract_track_data(result: AnalysisResult) -> dict[str, str]:
+    """
+    Build a normalised dict of track data from an AnalysisResult.
+
+    All values are strings for direct CSV serialisation.
+    Pure function — no I/O.
+    """
+    return {**_extract_audio_fields(result), **_extract_verdict_fields(result)}
+
+
+def _disco_row(data: dict[str, str]) -> dict[str, str]:
+    """Map normalised data to DISCO catalog import columns. Pure — no I/O."""
+    tags_parts = [f"GRADE:{data['grade']}"] if data["grade"] else []
+    if data["verdict"]:
+        tags_parts.append(f"AI-VERDICT:{data['verdict'].replace(' ', '-')}")
+    if data["flags"] != "none":
+        for f in data["flags"].split(" | "):
+            tags_parts.append(f"FLAG:{f}")
+    if data["sync_safe_cleared"] == "true":
+        tags_parts.append("SYNC_SAFE_CLEARED")
+
+    notes_parts = []
+    if data["ai_probability_pct"]:
+        notes_parts.append(f"AI probability: {data['ai_probability_pct']}%")
+    if data["lufs_integrated"]:
+        notes_parts.append(f"Integrated LUFS: {data['lufs_integrated']}")
+    if data["pro"]:
+        notes_parts.append(f"PRO: {data['pro']}")
+
+    return {
+        "title": data["title"], "artist": data["artist"],
+        "bpm":   data["bpm"],   "key":    data["key"],
+        "isrc":  data["isrc"],
+        "tags":  ", ".join(tags_parts),
+        "notes": " | ".join(notes_parts),
+    }
+
+
+def _synchtank_row(data: dict[str, str]) -> dict[str, str]:
+    """Map normalised data to Synchtank catalog import columns. Pure — no I/O."""
+    desc_parts = []
+    if data["grade"]:
+        desc_parts.append(f"Sync-Safe Grade: {data['grade']}")
+    if data["ai_probability_pct"] and data["verdict"]:
+        desc_parts.append(f"AI: {data['ai_probability_pct']}% ({data['verdict']})")
+    if data["flags"] != "none":
+        desc_parts.append(f"Flags: {data['flags']}")
+    if data["sync_safe_cleared"] == "true":
+        desc_parts.append("Pre-cleared: yes")
+    if data["lufs_integrated"]:
+        desc_parts.append(f"LUFS: {data['lufs_integrated']}")
+
+    return {
+        "track_title":   data["title"],  "artist_name":   data["artist"],
+        "tempo":         data["bpm"],    "key_signature": data["key"],
+        "isrc_code":     data["isrc"],
+        "description":   " | ".join(desc_parts),
+    }
+
+
+def _to_platform_row(data: dict[str, str], platform: str) -> dict[str, str]:
+    """
+    Map normalised track data to a platform-specific column dict.
+
+    Pure function — no I/O.
+
+    Args:
+        data:     Output of _extract_track_data.
+        platform: One of "generic", "disco", "synchtank".
+
+    Returns:
+        Dict keyed by platform column names, values as strings.
+
+    Raises:
+        ValueError: if *platform* is not a recognised schema name.
+    """
+    if platform == "generic":
+        return {col: data.get(col, "") for col in PLATFORM_SCHEMAS["generic"]}
+    if platform == "disco":
+        return _disco_row(data)
+    if platform == "synchtank":
+        return _synchtank_row(data)
+    raise ValueError(f"Unknown platform '{platform}'. Valid: {list(PLATFORM_SCHEMAS)}")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def to_platform_csv(result: AnalysisResult, platform: str = "generic") -> bytes:
+    """
+    Generate a single-row platform CSV for catalog import.
+
+    Pure function — no I/O, no Streamlit calls.
+
+    Args:
+        result:   Complete pipeline AnalysisResult.
+        platform: Target platform schema. One of "generic", "disco", "synchtank".
+
+    Returns:
+        UTF-8-with-BOM encoded CSV bytes (BOM ensures Excel opens correctly).
+
+    Raises:
+        ValueError: if *platform* is not a recognised schema name.
+    """
+    if platform not in PLATFORM_SCHEMAS:
+        raise ValueError(f"Unknown platform '{platform}'. Valid: {list(PLATFORM_SCHEMAS)}")
+    columns = PLATFORM_SCHEMAS[platform]
+    data    = _extract_track_data(result)
+    row     = _to_platform_row(data, platform)
+
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=columns, extrasaction="ignore")
+    writer.writeheader()
+    writer.writerow(row)
+
+    return buf.getvalue().encode("utf-8-sig")

--- a/tests/test_platform_export.py
+++ b/tests/test_platform_export.py
@@ -1,0 +1,253 @@
+"""
+tests/test_platform_export.py
+Unit tests for services/platform_export.py pure functions.
+"""
+from __future__ import annotations
+
+import csv
+import io
+
+import pytest
+
+from core.models import (
+    AnalysisResult,
+    AudioBuffer,
+    AudioQualityResult,
+    ComplianceFlag,
+    ComplianceReport,
+    EnergyEvolutionResult,
+    ForensicsResult,
+    IntroResult,
+    LegalLinks,
+    StingResult,
+    StructureResult,
+)
+from services.platform_export import (
+    PLATFORM_SCHEMAS,
+    _extract_track_data,
+    _to_platform_row,
+    to_platform_csv,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_result(
+    title: str = "Test Track",
+    artist: str = "Test Artist",
+    bpm: float | str = 120.0,
+    key: str = "C Major",
+    isrc: str = "US-ABC-23-12345",
+    grade: str = "A",
+    ai_probability: float = 0.1,
+    verdict: str = "Likely Not AI",
+    flags: list[ComplianceFlag] | None = None,
+    lufs: float = -14.0,
+) -> AnalysisResult:
+    compliance = ComplianceReport(
+        flags=flags or [],
+        sting=StingResult(ending_type="fade", sync_ready=True, final_energy_ratio=0.1),
+        evolution=EnergyEvolutionResult(stagnant_windows=0, total_windows=8, detail=""),
+        intro=IntroResult(intro_seconds=4.0),
+        grade=grade,
+    )
+    forensics = ForensicsResult(
+        ai_probability=ai_probability,
+        verdict=verdict,  # type: ignore[arg-type]
+    )
+    structure = StructureResult(bpm=bpm, key=key, sections=[], beats=[])
+    legal     = LegalLinks(isrc=isrc, pro_match="ASCAP (US)")
+    audio_quality = AudioQualityResult(
+        integrated_lufs=lufs,
+        true_peak_dbfs=-1.5,
+        loudness_range_lu=8.0,
+        delta_spotify=0.0,
+        delta_apple_music=2.0,
+        delta_youtube=0.0,
+        delta_broadcast=9.0,
+        true_peak_warning=False,
+        dialogue_score=0.75,
+        dialogue_label="Dialogue-Ready",
+    )
+    return AnalysisResult(
+        audio=AudioBuffer(
+            raw=b"\x00" * 44,
+            label="Test Track",
+            metadata={"title": title, "artist": artist},
+        ),
+        compliance=compliance,
+        forensics=forensics,
+        structure=structure,
+        legal=legal,
+        audio_quality=audio_quality,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _extract_track_data
+# ---------------------------------------------------------------------------
+
+class TestExtractTrackData:
+    def test_basic_fields(self) -> None:
+        result = _make_result()
+        data   = _extract_track_data(result)
+        assert data["title"]  == "Test Track"
+        assert data["artist"] == "Test Artist"
+        assert data["bpm"]    == "120.0"
+        assert data["key"]    == "C Major"
+        assert data["isrc"]   == "US-ABC-23-12345"
+        assert data["grade"]  == "A"
+
+    def test_verdict_and_ai_probability(self) -> None:
+        result = _make_result(ai_probability=0.456)
+        data   = _extract_track_data(result)
+        assert data["ai_probability_pct"] == "45.6"
+        assert data["verdict"]            == "Likely Not AI"
+
+    def test_cleared_true_when_passing(self) -> None:
+        result = _make_result(grade="A", verdict="Likely Not AI")
+        assert _extract_track_data(result)["sync_safe_cleared"] == "true"
+
+    def test_cleared_false_when_ai_verdict(self) -> None:
+        result = _make_result(grade="A", verdict="Likely AI")
+        assert _extract_track_data(result)["sync_safe_cleared"] == "false"
+
+    def test_cleared_false_when_bad_grade(self) -> None:
+        result = _make_result(grade="D", verdict="Likely Not AI")
+        assert _extract_track_data(result)["sync_safe_cleared"] == "false"
+
+    def test_flags_pipe_separated(self) -> None:
+        flag = ComplianceFlag(
+            timestamp_s=10, issue_type="EXPLICIT",
+            text="bad", recommendation="remove",
+        )
+        result = _make_result(flags=[flag])
+        data   = _extract_track_data(result)
+        assert "EXPLICIT" in data["flags"]
+
+    def test_no_flags_shows_none(self) -> None:
+        result = _make_result(flags=[])
+        assert _extract_track_data(result)["flags"] == "none"
+
+    def test_bpm_string_falls_back_to_empty(self) -> None:
+        result = _make_result(bpm="Detection failed")
+        data   = _extract_track_data(result)
+        assert data["bpm"] == ""
+
+    def test_lufs_extracted(self) -> None:
+        result = _make_result(lufs=-16.0)
+        assert _extract_track_data(result)["lufs_integrated"] == "-16.0"
+
+
+# ---------------------------------------------------------------------------
+# to_platform_csv — generic
+# ---------------------------------------------------------------------------
+
+class TestToPlatformCsvGeneric:
+    def test_returns_bytes(self) -> None:
+        out = to_platform_csv(_make_result(), "generic")
+        assert isinstance(out, bytes)
+
+    def test_bom_present(self) -> None:
+        out = to_platform_csv(_make_result(), "generic")
+        assert out[:3] == b"\xef\xbb\xbf"
+
+    def test_header_matches_schema(self) -> None:
+        out    = to_platform_csv(_make_result(), "generic")
+        reader = csv.DictReader(io.StringIO(out.decode("utf-8-sig")))
+        assert set(reader.fieldnames or []) == set(PLATFORM_SCHEMAS["generic"])
+
+    def test_title_in_output(self) -> None:
+        out  = to_platform_csv(_make_result(title="MyTrack"), "generic")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert rows[0]["title"] == "MyTrack"
+
+    def test_sync_safe_cleared_field_present(self) -> None:
+        out  = to_platform_csv(_make_result(), "generic")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert rows[0]["sync_safe_cleared"] in ("true", "false")
+
+
+# ---------------------------------------------------------------------------
+# to_platform_csv — disco
+# ---------------------------------------------------------------------------
+
+class TestToPlatformCsvDisco:
+    def test_header_matches_schema(self) -> None:
+        out    = to_platform_csv(_make_result(), "disco")
+        reader = csv.DictReader(io.StringIO(out.decode("utf-8-sig")))
+        assert set(reader.fieldnames or []) == set(PLATFORM_SCHEMAS["disco"])
+
+    def test_tags_contains_grade(self) -> None:
+        out  = to_platform_csv(_make_result(grade="B"), "disco")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert "GRADE:B" in rows[0]["tags"]
+
+    def test_cleared_tag_present_when_passing(self) -> None:
+        out  = to_platform_csv(_make_result(grade="A", verdict="Likely Not AI"), "disco")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert "SYNC_SAFE_CLEARED" in rows[0]["tags"]
+
+    def test_notes_contains_ai_probability(self) -> None:
+        out  = to_platform_csv(_make_result(ai_probability=0.25), "disco")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert "25.0%" in rows[0]["notes"]
+
+
+# ---------------------------------------------------------------------------
+# to_platform_csv — synchtank
+# ---------------------------------------------------------------------------
+
+class TestToPlatformCsvSynchtank:
+    def test_header_matches_schema(self) -> None:
+        out    = to_platform_csv(_make_result(), "synchtank")
+        reader = csv.DictReader(io.StringIO(out.decode("utf-8-sig")))
+        assert set(reader.fieldnames or []) == set(PLATFORM_SCHEMAS["synchtank"])
+
+    def test_track_title_mapped(self) -> None:
+        out  = to_platform_csv(_make_result(title="MyTrack"), "synchtank")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert rows[0]["track_title"] == "MyTrack"
+
+    def test_tempo_mapped_from_bpm(self) -> None:
+        out  = to_platform_csv(_make_result(bpm=140.0), "synchtank")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert rows[0]["tempo"] == "140.0"
+
+    def test_description_contains_grade(self) -> None:
+        out  = to_platform_csv(_make_result(grade="C"), "synchtank")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert "Grade: C" in rows[0]["description"]
+
+    def test_pre_cleared_in_description(self) -> None:
+        out  = to_platform_csv(_make_result(grade="A", verdict="Not AI"), "synchtank")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert "Pre-cleared: yes" in rows[0]["description"]
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+class TestPlatformExportErrors:
+    def test_unknown_platform_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown platform"):
+            to_platform_csv(_make_result(), "unknown_platform")
+
+    def test_missing_structure_does_not_crash(self) -> None:
+        result = AnalysisResult(
+            audio=AudioBuffer(raw=b"\x00" * 44, label="x"),
+        )
+        out = to_platform_csv(result, "generic")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert rows[0]["bpm"] == ""
+
+    def test_missing_forensics_does_not_crash(self) -> None:
+        result = AnalysisResult(
+            audio=AudioBuffer(raw=b"\x00" * 44, label="x"),
+        )
+        out = to_platform_csv(result, "generic")
+        rows = list(csv.DictReader(io.StringIO(out.decode("utf-8-sig"))))
+        assert rows[0]["verdict"] == ""

--- a/ui/pages/report.py
+++ b/ui/pages/report.py
@@ -32,12 +32,20 @@ from core.models import (
     StructureResult,
     TranscriptSegment,
 )
+from services.platform_export import PLATFORM_SCHEMAS, to_platform_csv
 from ui.components import ISSUE_META, authorship_color, eq_bars, fmt_ts, issue_pill
 
 
 # AudioSource literal value for YouTube — matches core/models.py AudioSource type.
 # Defined here to avoid repeating the string across multiple render functions.
 _SOURCE_YOUTUBE: str = "youtube"
+
+# Human-readable labels for platform catalog export targets.
+_PLATFORM_LABELS: dict[str, str] = {
+    "generic":   "Generic CSV",
+    "disco":     "DISCO",
+    "synchtank": "Synchtank",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -1473,7 +1481,7 @@ def _pdf_flags_table(pdf: "FPDF", result: AnalysisResult) -> None:
 
 
 def _render_export_buttons(result: AnalysisResult) -> None:
-    """Render CSV and PDF export download buttons."""
+    """Render CSV, platform catalog, and PDF export download buttons."""
     st.markdown("""
     <div style="font-family:'Chakra Petch',monospace;font-size:.58rem;font-weight:600;
                 letter-spacing:.18em;text-transform:uppercase;color:var(--dim);
@@ -1487,12 +1495,12 @@ def _render_export_buttons(result: AnalysisResult) -> None:
     raw_slug   = result.audio.metadata.get("title", "") or result.audio.label or "sync-safe-report"
     track_slug = re.sub(r"[^\w\-.]", "-", raw_slug).strip("-")[:40].lower() or "sync-safe-report"
 
-    c_csv, c_pdf = st.columns(2, gap="medium")
+    c_csv, c_platform, c_pdf = st.columns(3, gap="medium")
 
     with c_csv:
         csv_bytes = _compliance_flags_to_csv(result)
         st.download_button(
-            label="⬇ Download CSV",
+            label="⬇ Compliance CSV",
             data=csv_bytes,
             file_name=f"{track_slug}-compliance.csv",
             mime="text/csv",
@@ -1500,11 +1508,14 @@ def _render_export_buttons(result: AnalysisResult) -> None:
             help="Compliance flags and structural checks as a spreadsheet",
         )
 
+    with c_platform:
+        _render_platform_export(result, track_slug)
+
     with c_pdf:
         try:
             pdf_bytes = _analysis_to_pdf(result)
             st.download_button(
-                label="⬇ Download PDF",
+                label="⬇ Certificate PDF",
                 data=bytes(pdf_bytes),
                 file_name=f"{track_slug}-certificate.pdf",
                 mime="application/pdf",
@@ -1515,6 +1526,30 @@ def _render_export_buttons(result: AnalysisResult) -> None:
             st.caption("PDF export requires fpdf2 — install with `pip install fpdf2`.")
         except Exception as exc:  # noqa: BLE001 — UI boundary; PDF errors must not crash the report
             st.error(f"PDF generation failed: {exc}")
+
+
+def _render_platform_export(result: AnalysisResult, track_slug: str) -> None:
+    """Render the 'Export for...' platform catalog dropdown + download button."""
+    platform_key = st.selectbox(
+        "Export for",
+        options=list(PLATFORM_SCHEMAS.keys()),
+        format_func=lambda k: _PLATFORM_LABELS.get(k, k),
+        key="export_platform_select",
+        label_visibility="collapsed",
+    )
+    try:
+        platform_bytes = to_platform_csv(result, platform_key)
+        label = _PLATFORM_LABELS.get(platform_key, platform_key)
+        st.download_button(
+            label=f"⬇ Export for {label}",
+            data=platform_bytes,
+            file_name=f"{track_slug}-{platform_key}.csv",
+            mime="text/csv",
+            use_container_width=True,
+            help=f"Single-row catalog CSV formatted for {label} import",
+        )
+    except Exception as exc:  # noqa: BLE001 — UI boundary
+        st.error(f"Platform export failed: {exc}")
 
 
 def _render_footer() -> None:


### PR DESCRIPTION
## Summary
- Pure `to_platform_csv(result, platform)` maps `AnalysisResult` to DISCO/Synchtank/Generic column schemas
- `SYNC_SAFE_CLEARED` tag computed from grade A/B + no hard flags + non-AI verdict
- `PlatformExportProvider` Protocol added to `core/protocols.py`
- 3-column export panel in report: Compliance CSV | Export for... dropdown | Certificate PDF

## Test plan
- [x] 26 unit tests: `pytest tests/test_platform_export.py` — all pass
- [ ] Manual: open report, select "DISCO" → download CSV → verify `GRADE:A`, `AI-VERDICT:...`, `SYNC_SAFE_CLEARED` in tags column
- [ ] Manual: select "Synchtank" → verify `track_title`, `tempo`, `description` columns
- [ ] Manual: select "Generic CSV" → verify all 12 columns present with BOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)