### PR TITLE
feat: expand audio sources — Bandcamp, SoundCloud, direct links (issue #28)

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -32,7 +32,7 @@ Severity     = Literal["hard", "soft"]
 EndingType   = Literal["sting", "fade", "cut"]
 AIVerdict    = Literal["Likely Human", "Uncertain", "Likely AI", "Insufficient data"]
 ForensicVerdict = Literal["AI", "Likely AI", "Likely Not AI", "Not AI", "Insufficient data"]
-AudioSource  = Literal["youtube", "file"]
+AudioSource  = Literal["youtube", "file", "bandcamp", "soundcloud", "direct"]
 
 
 # ---------------------------------------------------------------------------

--- a/services/ingestion.py
+++ b/services/ingestion.py
@@ -32,6 +32,21 @@ from core.exceptions import AudioSourceError, ConfigurationError, ValidationErro
 from core.models import AudioBuffer
 from utils.security import validate_url
 
+# ---------------------------------------------------------------------------
+# URL classification constants (module-level for testability)
+# ---------------------------------------------------------------------------
+
+_YOUTUBE_HOSTS: frozenset[str] = frozenset({
+    "youtube.com", "www.youtube.com", "m.youtube.com", "youtu.be",
+})
+_BANDCAMP_HOSTS: frozenset[str] = frozenset({"bandcamp.com"})
+_SOUNDCLOUD_HOSTS: frozenset[str] = frozenset({
+    "soundcloud.com", "www.soundcloud.com", "on.soundcloud.com",
+})
+_DIRECT_AUDIO_EXTENSIONS: frozenset[str] = frozenset({
+    ".mp3", ".wav", ".flac", ".ogg", ".m4a", ".aac",
+})
+
 
 class Ingestion:
     """
@@ -75,14 +90,23 @@ class Ingestion:
             ConfigurationError:  yt-dlp or ffmpeg binary not found.
         """
         if isinstance(source, str):
-            return self._load_youtube(source)
+            kind = _classify_url(source)
+            if kind == "unknown":
+                raise ValidationError(
+                    "Unsupported URL — only YouTube, Bandcamp, SoundCloud, "
+                    "and direct audio links (.mp3/.wav/.flac/.ogg/.m4a/.aac) are supported.",
+                    context={"url": source},
+                )
+            if kind == "direct":
+                return self._load_direct(source)
+            return self._load_ytdlp(source, source_label=kind)
         return self._load_upload(source)
 
     # ------------------------------------------------------------------
-    # Private: YouTube path
+    # Private: yt-dlp path (YouTube, Bandcamp, SoundCloud)
     # ------------------------------------------------------------------
 
-    def _load_youtube(self, url: str) -> AudioBuffer:
+    def _load_ytdlp(self, url: str, source_label: str = "youtube") -> AudioBuffer:
         try:
             validate_url(url)
         except ValueError as exc:
@@ -179,13 +203,61 @@ class Ingestion:
                 sample_rate=CONSTANTS.SAMPLE_RATE,
                 label=_label_from_url(url),
                 metadata=track_metadata,
-                source="youtube",
+                source=source_label,  # type: ignore[arg-type]
             )
 
         finally:
             for proc in (ytdlp_proc, ffmpeg_proc):
                 if proc and proc.poll() is None:
                     proc.kill()
+
+    # ------------------------------------------------------------------
+    # Private: direct HTTP audio download
+    # ------------------------------------------------------------------
+
+    def _load_direct(self, url: str) -> AudioBuffer:
+        """Download a direct audio URL into an AudioBuffer."""
+        import urllib.error
+        max_bytes = CONSTANTS.MAX_UPLOAD_BYTES
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "sync-safe/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                chunks: list[bytes] = []
+                total = 0
+                while True:
+                    chunk = resp.read(65536)
+                    if not chunk:
+                        break
+                    total += len(chunk)
+                    if total > max_bytes:
+                        raise AudioSourceError(
+                            f"Direct download exceeds {max_bytes} byte limit.",
+                            context={"url": url},
+                        )
+                    chunks.append(chunk)
+                raw = b"".join(chunks)
+        except AudioSourceError:
+            raise
+        except urllib.error.URLError as exc:
+            raise AudioSourceError(
+                "Direct audio download failed.",
+                context={"url": url, "error": str(exc)},
+            ) from exc
+
+        if not raw:
+            raise AudioSourceError("Direct download produced empty bytes.", context={"url": url})
+
+        _check_size(len(raw), self._settings.max_upload_mb)
+
+        from pathlib import PurePosixPath
+        from urllib.parse import urlparse as _urlparse
+        label = PurePosixPath(_urlparse(url).path).name or url
+        return AudioBuffer(
+            raw=raw,
+            sample_rate=CONSTANTS.SAMPLE_RATE,
+            label=label,
+            source="direct",
+        )
 
     # ------------------------------------------------------------------
     # Private: file-upload path
@@ -226,6 +298,31 @@ class Ingestion:
 # ---------------------------------------------------------------------------
 # Module-level pure functions (testable without instantiating the service)
 # ---------------------------------------------------------------------------
+
+def _classify_url(url: str) -> str:
+    """
+    Classify a URL as one of: youtube / bandcamp / soundcloud / direct / unknown.
+
+    Pure function — no I/O, no side effects, deterministic.
+    Returns "unknown" on any parse error rather than raising.
+    """
+    try:
+        parsed = urlparse(url.strip())
+        host   = parsed.netloc.lower().removeprefix("www.")
+        if host in _YOUTUBE_HOSTS or host == "youtu.be":
+            return "youtube"
+        if host in _BANDCAMP_HOSTS or host.endswith(".bandcamp.com"):
+            return "bandcamp"
+        if host in _SOUNDCLOUD_HOSTS:
+            return "soundcloud"
+        from pathlib import PurePosixPath
+        ext = PurePosixPath(parsed.path).suffix.lower()
+        if ext in _DIRECT_AUDIO_EXTENSIONS:
+            return "direct"
+        return "unknown"
+    except Exception:   # noqa: BLE001 — pure parse helper; never fatal
+        return "unknown"
+
 
 def _find_binary(name: str) -> str:
     """

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -165,9 +165,10 @@ class TestFetchYoutubeAudio:
             with pytest.raises(AudioSourceError, match="empty"):
                 self.svc.load(self.VALID_URL)
 
-    def test_raises_validation_error_for_non_youtube_url(self):
+    def test_raises_validation_error_for_unsupported_url(self):
+        # Spotify is not in the supported source list; "unknown" classification → ValidationError
         with pytest.raises(ValidationError) as exc_info:
-            self.svc.load("https://evil.com/audio.mp3")
+            self.svc.load("https://open.spotify.com/track/abc123")
         assert "url" in exc_info.value.context
 
     def test_raises_validation_error_for_http_url(self):
@@ -190,3 +191,43 @@ class TestFetchYoutubeAudio:
     def test_satisfies_audio_provider_protocol(self):
         from core.protocols import AudioProvider
         assert isinstance(self.svc, AudioProvider)
+
+
+# ---------------------------------------------------------------------------
+# _classify_url
+# ---------------------------------------------------------------------------
+
+class TestClassifyUrl:
+    """Tests for the pure URL classification function."""
+
+    def test_youtube_dot_com(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") == "youtube"
+
+    def test_youtu_be_short(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("https://youtu.be/dQw4w9WgXcQ") == "youtube"
+
+    def test_bandcamp_subdomain(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("https://artist.bandcamp.com/track/song-name") == "bandcamp"
+
+    def test_soundcloud(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("https://soundcloud.com/artist/track") == "soundcloud"
+
+    def test_direct_mp3(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("https://example.com/audio/track.mp3") == "direct"
+
+    def test_direct_wav(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("https://cdn.example.com/files/track.wav") == "direct"
+
+    def test_unknown_url(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("https://spotify.com/track/abc") == "unknown"
+
+    def test_malformed_url_returns_unknown(self):
+        from services.ingestion import _classify_url
+        assert _classify_url("not-a-url") == "unknown"

--- a/utils/security.py
+++ b/utils/security.py
@@ -9,14 +9,21 @@ import shlex
 from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
-# Allowlisted YouTube hostnames
+# Allowlisted hostnames for yt-dlp-routed downloads
 # ---------------------------------------------------------------------------
 _ALLOWED_HOSTS = frozenset({
+    # YouTube
     "youtube.com",
     "www.youtube.com",
     "youtu.be",
     "music.youtube.com",
     "m.youtube.com",
+    # Bandcamp (subdomains matched separately in ingestion via _BANDCAMP_HOSTS)
+    "bandcamp.com",
+    # SoundCloud
+    "soundcloud.com",
+    "www.soundcloud.com",
+    "on.soundcloud.com",
 })
 
 # Control characters (excluding normal whitespace) and null bytes
@@ -60,10 +67,11 @@ def validate_url(url: str) -> str:
         raise ValueError("URLs with embedded credentials are not accepted.")
 
     host = (parsed.hostname or "").lower()
-    if host not in _ALLOWED_HOSTS:
+    if host not in _ALLOWED_HOSTS and not host.endswith(".bandcamp.com"):
         raise ValueError(
             f"URL host '{host}' is not on the allowlist. "
-            f"Accepted hosts: {', '.join(sorted(_ALLOWED_HOSTS))}"
+            f"Accepted hosts: {', '.join(sorted(_ALLOWED_HOSTS))} "
+            f"(or any *.bandcamp.com subdomain)"
         )
 
     return url


### PR DESCRIPTION
## Summary
- `AudioSource` literal expanded: `youtube / file / bandcamp / soundcloud / direct`
- `_classify_url()` pure function: domain + extension-based classification
- `_load_ytdlp()` replaces `_load_youtube()` — accepts `source_label`, routes Bandcamp/SoundCloud through existing yt-dlp path natively
- `_load_direct()` for direct audio URLs — streaming with `MAX_UPLOAD_BYTES` guard
- `utils/security.py` `_ALLOWED_HOSTS` expanded with Bandcamp + SoundCloud hosts

## Test plan
- [x] `pytest tests/test_ingestion.py` — 28 tests pass (8 new `TestClassifyUrl`)
- [x] `pytest tests/ --quiet` — full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)