### PR TITLE
feat(compliance): add LOCATION issue type via spaCy GPE NER (issue #39)

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, ConfigDict, Field
 # Type aliases — used as Literal constraints throughout
 # ---------------------------------------------------------------------------
 
-IssueType    = Literal["EXPLICIT", "BRAND", "VIOLENCE", "DRUGS"]
+IssueType    = Literal["EXPLICIT", "BRAND", "LOCATION", "VIOLENCE", "DRUGS"]
 Confidence   = Literal["confirmed", "potential"]
 Severity     = Literal["hard", "soft"]
 EndingType   = Literal["sting", "fade", "cut"]

--- a/services/compliance.py
+++ b/services/compliance.py
@@ -77,13 +77,18 @@ _MIN_SEGMENT_CHARS: int = 20
 # Only these issue types count toward the A–F content grade
 _GRADE_ISSUE_TYPES: frozenset[str] = frozenset({"EXPLICIT", "VIOLENCE", "DRUGS"})
 
-# NER entity labels mapped to our issue types
+# NER entity labels mapped to our issue types.
+# ORG → BRAND: trademarked company/product names (Nike, Spotify, etc.)
+# GPE → LOCATION: geo-political entities (countries, cities, regions) that may
+#   create placement restrictions in international licensing contexts.
 _NER_ISSUE_MAP: dict[str, IssueType] = {
-    "ORG": "BRAND",
+    "ORG":  "BRAND",
+    "GPE":  "LOCATION",
 }
 
 _NER_RECOMMENDATIONS: dict[IssueType, str] = {
-    "BRAND": "Confirm explicit brand clearance with rights holder.",
+    "BRAND":    "Confirm explicit brand clearance with rights holder.",
+    "LOCATION": "Geographic reference — verify placement restrictions for international markets.",
 }
 
 
@@ -408,7 +413,9 @@ class Compliance:
                 if pf.contains_profanity(seg.text):
                     try:
                         obs = float(detector.predict(seg.text).get("obscene", 0.0))
-                    except Exception:  # noqa: BLE001 — Detoxify predict is best-effort; fall back to potential
+                    except (RuntimeError, ValueError, TypeError, KeyError):
+                        # Detoxify predict is best-effort; treat as potential on any
+                        # numeric/runtime failure rather than dropping the profanity hit.
                         obs = _EXPLICIT_POTENTIAL
 
                     if obs >= _EXPLICIT_CONFIRMED:
@@ -450,9 +457,9 @@ class Compliance:
             # Curated brand keywords → BRAND (potential)
             raw_flags.extend(_check_brand_keywords(seg.text, ts, self._brand_patterns))
 
-            # spaCy NER → BRAND (ORG, potential) — downgraded to potential
-            # because NER in song lyrics produces too many false positives
-            # (e.g. terms of endearment and common nouns mis-classified as ORG).
+            # spaCy NER → BRAND (ORG) / LOCATION (GPE) — both downgraded to
+            # potential because NER in song lyrics produces many false positives
+            # (terms of endearment mis-classified as ORG, etc.).
             if nlp is not None:
                 try:
                     doc = nlp(seg.text)
@@ -466,7 +473,9 @@ class Compliance:
                                 recommendation=_NER_RECOMMENDATIONS[issue_type],
                                 confidence="potential",
                             ))
-                except Exception:  # noqa: BLE001 — NER is supplementary
+                except (OSError, RuntimeError, ValueError):
+                    # spaCy model load errors or tokenizer failures are non-fatal;
+                    # NER is supplementary — pipeline continues without it.
                     pass
 
         return _deduplicate_flags(raw_flags)

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -29,6 +29,8 @@ from core.models import (
 )
 from services.compliance import (
     Compliance,
+    _NER_ISSUE_MAP,
+    _NER_RECOMMENDATIONS,
     _build_windows,
     _check_brand_keywords,
     _compute_grade,
@@ -328,3 +330,89 @@ class TestCheckIntro:
         result = self.svc._check_intro(sections=[], transcript=[])
         assert result.flag is False
         assert result.source == "none"
+
+
+# ---------------------------------------------------------------------------
+# NER issue map — GPE → LOCATION, ORG → BRAND
+# ---------------------------------------------------------------------------
+
+class TestNerIssueMap:
+    def test_org_maps_to_brand(self):
+        assert _NER_ISSUE_MAP["ORG"] == "BRAND"
+
+    def test_gpe_maps_to_location(self):
+        assert _NER_ISSUE_MAP["GPE"] == "LOCATION"
+
+    def test_no_unexpected_keys(self):
+        # Only ORG and GPE should be mapped — other spaCy labels are ignored
+        assert set(_NER_ISSUE_MAP.keys()) == {"ORG", "GPE"}
+
+    def test_brand_recommendation_present(self):
+        assert "BRAND" in _NER_RECOMMENDATIONS
+        assert len(_NER_RECOMMENDATIONS["BRAND"]) > 0
+
+    def test_location_recommendation_present(self):
+        assert "LOCATION" in _NER_RECOMMENDATIONS
+        assert len(_NER_RECOMMENDATIONS["LOCATION"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# _audit_lyrics — pure paths that don't require Detoxify/spaCy/GPU
+# ---------------------------------------------------------------------------
+
+class TestAuditLyricsGuards:
+    """Tests for _audit_lyrics guard clauses and empty-segment handling."""
+
+    def setup_method(self):
+        self.svc = Compliance()
+
+    def test_empty_transcript_returns_empty(self):
+        # Whisper empty segments must not raise — this is the primary guard
+        result = self.svc._audit_lyrics([])
+        assert result == []
+
+    def test_all_short_segments_skipped_for_detoxify(self):
+        # Segments shorter than _MIN_SEGMENT_CHARS bypass Pass 2 (Detoxify)
+        # but are still checked by Pass 1 (profanity) if profanity filter loads.
+        # Without real models this just confirms no crash.
+        short_segs = [_segment("ok", start=float(i)) for i in range(5)]
+        # Should complete without raising even if models are unavailable
+        try:
+            self.svc._audit_lyrics(short_segs)
+        except Exception as exc:  # noqa: BLE001
+            # ModelInferenceError is acceptable (Detoxify not installed in test env)
+            from core.exceptions import ModelInferenceError
+            assert isinstance(exc, ModelInferenceError), f"Unexpected: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# LOCATION IssueType — round-trip through ComplianceFlag model
+# ---------------------------------------------------------------------------
+
+class TestLocationIssueType:
+    def test_compliance_flag_accepts_location_issue_type(self):
+        flag = ComplianceFlag(
+            timestamp_s=30,
+            issue_type="LOCATION",
+            text="New York",
+            recommendation="Geographic reference — verify placement restrictions.",
+            confidence="potential",
+            severity="soft",
+        )
+        assert flag.issue_type == "LOCATION"
+
+    def test_location_flag_excluded_from_grade_computation(self):
+        # LOCATION flags do not lower grade below B (same as BRAND) — confirmed soft
+        # flags of any type trigger B, but LOCATION never escalates to C/D/F.
+        flags = [
+            ComplianceFlag(
+                timestamp_s=i * 10,
+                issue_type="LOCATION",
+                text=f"city{i}",
+                recommendation="check markets",
+                confidence="confirmed",
+                severity="soft",
+            )
+            for i in range(5)
+        ]
+        assert _compute_grade(flags) == "B"

--- a/ui/components.py
+++ b/ui/components.py
@@ -17,11 +17,13 @@ from core.models import ComplianceFlag
 _CLR_BRAND: str    = "#F5A623"
 _CLR_EXPLICIT: str = "#FF3060"
 _CLR_VIOLENCE: str = "#FF6B35"
+_CLR_LOCATION: str = "#60A5FA"   # blue — geographic references, not inherently harmful
 _CLR_NEEDS_REVIEW: str = "#C8E86A"
 
 ISSUE_META: dict[str, dict] = {
     "BRAND":    {"icon": "🏢", "color": _CLR_BRAND},
     "EXPLICIT": {"icon": "🔞", "color": _CLR_EXPLICIT},
+    "LOCATION": {"icon": "📍", "color": _CLR_LOCATION},
     "VIOLENCE": {"icon": "⚠️",  "color": _CLR_VIOLENCE},
     "DRUGS":    {"icon": "💊", "color": _CLR_EXPLICIT},
 }


### PR DESCRIPTION
## Summary
- Extends `IssueType` Literal with `"LOCATION"` in `core/models.py`
- Maps spaCy `GPE` entities → `LOCATION` flags (potential confidence, soft severity) alongside existing `ORG` → `BRAND` mapping; adds international licensing placement recommendation
- Tightens two bare `except Exception` catches in `_audit_lyrics` to specific exception types

## Changes
- `core/models.py` — `IssueType` Literal gains `"LOCATION"`
- `services/compliance.py` — `_NER_ISSUE_MAP` adds `GPE → LOCATION`; `_NER_RECOMMENDATIONS` adds LOCATION entry; exception specificity improved in Detoxify and spaCy NER blocks
- `ui/components.py` — `_CLR_LOCATION = "#60A5FA"` (blue) + 📍 icon added to `ISSUE_META`
- `tests/test_compliance.py` — 9 new tests across `TestNerIssueMap`, `TestAuditLyricsGuards`, `TestLocationIssueType` (408 passing)

## Test plan
- [x] `pytest tests/test_compliance.py -q` — 44 passed
- [x] `pytest -q` — 408 passed, 0 failures
- [x] `/review` passed — READY TO COMMIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)