### PR TITLE
fix(timeout): skip SIGALRM on non-main threads — fixes Streamlit ingestion crash (#65)

### DIFF
--- a/core/timeout.py
+++ b/core/timeout.py
@@ -2,8 +2,11 @@
 core/timeout.py
 Wall-clock timeout context manager for pipeline steps.
 
-Uses POSIX SIGALRM — works on Linux (HF Spaces) and macOS.
-Must be called from the main thread (SIGALRM restriction).
+Uses POSIX SIGALRM on the main thread (Linux / macOS).
+Falls back to a no-op yield on non-main threads (e.g. Streamlit's
+ScriptRunner), because signal.signal() and signal.alarm() are restricted
+to the main Python thread — calling them from any other thread raises
+ValueError: "signal only works in main thread of the main interpreter".
 
 Usage:
     from core.timeout import step_timeout
@@ -15,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import signal
+import threading
 import time
 from collections.abc import Generator
 
@@ -27,13 +31,28 @@ def step_timeout(seconds: int, step_key: str) -> Generator[None, None, None]:
     Context manager that raises StepTimeoutError if the block runs longer
     than `seconds` wall-clock seconds.
 
+    On the main thread, SIGALRM provides reliable timeout enforcement that
+    interrupts blocking syscalls (subprocess.communicate, socket I/O, etc.).
+
+    On non-main threads (Streamlit's ScriptThread, test workers), SIGALRM is
+    unavailable. The block runs without a timeout guard — Streamlit's global
+    ZeroGPU session limit (25 min/day) acts as the outer hard cap.
+
     Args:
         seconds:  Budget in whole seconds.
         step_key: Pipeline step name for the error context.
 
     Raises:
-        StepTimeoutError: if the budget is exceeded.
+        StepTimeoutError: if the budget is exceeded (main thread only).
     """
+    if threading.current_thread() is not threading.main_thread():
+        # SIGALRM is restricted to the main thread. Streamlit runs its script
+        # runner in a daemon thread, so we yield without installing a handler.
+        # Tests that exercise timeout behaviour must do so from the main thread
+        # or use a dedicated test helper that patches signal directly.
+        yield
+        return
+
     start = time.monotonic()
 
     def _handler(signum: int, frame: object) -> None:
@@ -48,5 +67,5 @@ def step_timeout(seconds: int, step_key: str) -> Generator[None, None, None]:
     try:
         yield
     finally:
-        signal.alarm(0)                          # cancel any pending alarm
+        signal.alarm(0)                             # cancel any pending alarm
         signal.signal(signal.SIGALRM, old_handler)  # restore previous handler


### PR DESCRIPTION
## Summary
- `step_timeout` used `signal.signal(SIGALRM)` + `signal.alarm()`, which Python restricts to the main thread
- Streamlit runs its ScriptRunner in a daemon thread, so every `with step_timeout(...)` call crashed immediately
- Fix adds a `threading.current_thread() is not threading.main_thread()` guard — non-main threads yield through; main thread retains SIGALRM

## Root cause
```
ValueError: signal only works in main thread of the main interpreter
  File "core/timeout.py", line 46, in step_timeout
    old_handler = signal.signal(signal.SIGALRM, _handler)
```

## Test plan
- [x] `pytest -q` — 408 passed, existing `test_timeout.py` SIGALRM tests unchanged
- [x] Non-main thread path: yields without timeout guard (no crash)
- [x] Main thread path: SIGALRM behaviour preserved for pytest + direct invocation

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)