### PR TITLE
fix(ui): constrain Launch Portal button size to match nav bar height (#66)

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,6 +110,13 @@ _THEME_JS = """<script>
           container.querySelectorAll('[data-testid="stBaseButton-secondary"]').forEach(function(btn) {
             btn.setAttribute('data-nav-btn', pair[1]);
           });
+          // Primary CTA button ("Launch Portal →") — stamp separately so CSS
+          // can constrain its size to match the nav bar height.
+          if (pair[1] === 'nav') {
+            container.querySelectorAll('[data-testid="stBaseButton-primary"]').forEach(function(btn) {
+              btn.setAttribute('data-nav-btn', 'nav-cta');
+            });
+          }
         });
       });
     }

--- a/ui/styles.py
+++ b/ui/styles.py
@@ -662,6 +662,23 @@ html body div[data-testid="stButton"]:has(button[data-nav-btn="nav"]):hover {
   box-shadow: none !important;
 }
 
+/* Nav CTA — "Launch Portal →" primary button, constrained to nav height */
+html body button[data-nav-btn="nav-cta"] {
+  padding: 0.35rem 0.9rem !important;
+  font-size: .82rem !important;
+  font-weight: 600 !important;
+  font-family: 'Figtree', sans-serif !important;
+  white-space: nowrap !important;
+  border-radius: 6px !important;
+  line-height: 1.4 !important;
+  min-height: unset !important;
+  height: auto !important;
+}
+html body button[data-nav-btn="nav-cta"]:focus-visible {
+  outline: 2px solid var(--accent) !important;
+  outline-offset: 3px !important;
+}
+
 /* Footer link buttons — block-level plain text */
 html body button[data-nav-btn="footer"] {
   all: unset !important;


### PR DESCRIPTION
## Summary
The primary "Launch Portal →" button used Streamlit full default sizing because the JS marker only stamped `data-nav-btn="nav"` on secondary buttons. Primary button was unstyled and rendered much larger than surrounding nav links.

- `app.py` JS: stamps `data-nav-btn="nav-cta"` on primary buttons within the nav container
- `styles.py`: `nav-cta` rule constrains padding (`0.35rem 0.9rem`), font-size (`.82rem`), border-radius (`6px`) to match nav proportions

## Test plan
- [x] `pytest -q` — 428 passed

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)