### PR TITLE
feat(discovery): multi-signal popularity - Spotify + platform engagement + blended 0-100 score

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -191,12 +191,29 @@ class SystemConstants:
     DIALOGUE_READY_HIGH: float = 0.70   # ≥ this → "Dialogue-Ready"
     DIALOGUE_READY_LOW: float  = 0.40   # < this → "Dialogue-Heavy"; between → "Mixed"
 
-    # ---- Track Popularity (Last.fm listener counts) ---------------------------
-    # Tier boundaries based on Last.fm unique listener counts.
+    # ---- Track Popularity (blended 0–100 score) --------------------------------
+    # Tier boundaries applied to the normalised popularity_score (0–100).
+    # Score is derived from whichever signals are available:
+    #   Last.fm listeners, Last.fm playcount, YouTube/platform view count,
+    #   YouTube like count, Spotify popularity (0–100 native).
+    # Each signal is normalised independently then the max is taken so a strong
+    # signal on any single platform cannot be drowned out by weak others.
     # Tiers: Emerging < Regional < Mainstream < Global
-    POPULARITY_REGIONAL_MIN: int    = 10_000
-    POPULARITY_MAINSTREAM_MIN: int  = 100_000
-    POPULARITY_GLOBAL_MIN: int      = 1_000_000
+    POPULARITY_REGIONAL_MIN: int    = 25    # normalised score ≥ 25
+    POPULARITY_MAINSTREAM_MIN: int  = 50    # normalised score ≥ 50
+    POPULARITY_GLOBAL_MIN: int      = 75    # normalised score ≥ 75
+
+    # Last.fm listener count ceilings for per-signal normalisation.
+    # Raw listener counts above the ceiling are clamped to 100.
+    LASTFM_LISTENERS_REGIONAL: int    = 10_000
+    LASTFM_LISTENERS_MAINSTREAM: int  = 100_000
+    LASTFM_LISTENERS_GLOBAL: int      = 1_000_000
+
+    # YouTube / platform view count ceilings for normalisation.
+    # Calibrated against known mainstream (100M+ views) and emerging (<1M) tracks.
+    PLATFORM_VIEWS_REGIONAL: int    = 1_000_000     # 1M views → score ~25
+    PLATFORM_VIEWS_MAINSTREAM: int  = 50_000_000    # 50M views → score ~50
+    PLATFORM_VIEWS_GLOBAL: int      = 500_000_000   # 500M views → score ~75+
 
     # Estimated sync fee ranges (USD) per popularity tier — shown as guidance only.
     # Source: industry averages 2024-2026; highly variable by usage and territory.
@@ -712,6 +729,15 @@ class Settings(BaseSettings):
         default="",
         description="Last.fm API key for similar-track discovery. "
                     "Get one at https://www.last.fm/api/account/create",
+    )
+    spotify_client_id: str = Field(
+        default="",
+        description="Spotify Web API client ID for popularity score lookup. "
+                    "Create an app at https://developer.spotify.com/dashboard",
+    )
+    spotify_client_secret: str = Field(
+        default="",
+        description="Spotify Web API client secret (pairs with spotify_client_id).",
     )
     hf_token: Optional[str] = Field(
         default=None,

--- a/core/models.py
+++ b/core/models.py
@@ -333,15 +333,34 @@ class AudioQualityResult(BaseModel):
 
 
 class PopularityResult(BaseModel):
-    """Last.fm popularity data for the scanned track."""
+    """
+    Multi-signal popularity result for the scanned track.
+
+    popularity_score is a normalised 0–100 value derived from whichever
+    signals are available (Last.fm, Spotify, platform engagement).  tier
+    is derived from popularity_score so the tier cannot be dragged down by
+    a single bad Last.fm lookup.
+
+    platform_metrics holds raw per-platform engagement counts keyed by
+    field name (e.g. "view_count", "like_count", "share_count").  Values
+    are source-dependent and may be absent when the scan is from a file
+    upload rather than a URL.
+
+    Designed to be re-fetched independently of the static forensic signals
+    once result caching is added (issue #84) — popularity data goes stale,
+    forensic data does not.
+    """
 
     model_config = ConfigDict(frozen=True)
 
-    listeners: int           # unique listeners on Last.fm
-    playcount: int           # total scrobbles on Last.fm
-    tier: str                # "Emerging" | "Regional" | "Mainstream" | "Global"
-    sync_cost_low: int       # estimated sync fee lower bound (USD)
-    sync_cost_high: int      # estimated sync fee upper bound (USD)
+    listeners: int                                              # Last.fm unique listener count
+    playcount: int                                              # Last.fm total scrobble count
+    spotify_score: Optional[int]                               # Spotify popularity 0–100 (None if unavailable)
+    platform_metrics: dict[str, int] = Field(default_factory=dict)  # raw engagement: view_count, like_count, etc.
+    popularity_score: int                   # blended normalised 0–100 score
+    tier: str                               # "Emerging" | "Regional" | "Mainstream" | "Global"
+    sync_cost_low: int                      # estimated sync fee lower bound (USD)
+    sync_cost_high: int                     # estimated sync fee upper bound (USD)
 
     def to_dict(self) -> dict[str, Any]:
         return self.model_dump()

--- a/services/discovery.py
+++ b/services/discovery.py
@@ -22,6 +22,8 @@ Design notes:
 """
 from __future__ import annotations
 
+import base64
+import math
 import shutil
 import subprocess
 from pathlib import Path
@@ -102,41 +104,73 @@ class Discovery:
 
         return candidates
 
-    def get_track_popularity(self, title: str, artist: str) -> Optional[PopularityResult]:
+    def get_track_popularity(
+        self,
+        title: str,
+        artist: str,
+        platform_metrics: Optional[dict[str, int]] = None,
+    ) -> Optional[PopularityResult]:
         """
-        Fetch listener count and playcount from Last.fm track.getInfo.
+        Fetch multi-signal popularity data and return a blended PopularityResult.
 
-        Returns a PopularityResult with tier classification and estimated sync
-        cost range, or None when the track is not found or the API key is missing.
+        Signals gathered (each independently best-effort, never raises):
+          - Last.fm listeners + playcount via track.getInfo (autocorrect=1)
+          - Spotify popularity score (0–100) via client credentials OAuth
+          - Platform engagement metrics from AudioBuffer.metadata (view_count, etc.)
 
-        Never raises — popularity is supplementary metadata.
+        The blended popularity_score is the max of all normalised per-signal
+        scores, so a strong signal on any single platform cannot be suppressed
+        by a weak or missing one.  This prevents a bad Last.fm lookup from
+        misclassifying a mainstream track as "Emerging".
+
+        Returns None only when no signals are available at all.
         """
-        api_key = get_settings().lastfm_api_key
-        if not api_key or (not title and not artist):
+        if not title and not artist:
             return None
 
-        params = {
-            "method":      "track.getInfo",
-            "track":       title,
-            "artist":      artist,
-            "api_key":     api_key,
-            "format":      "json",
-            "autocorrect": 1,
-        }
+        settings = get_settings()
+        listeners, playcount = 0, 0
+        spotify_score: Optional[int] = None
+        metrics: dict[str, int] = platform_metrics or {}
 
-        try:
-            resp = requests.get(_LASTFM_BASE, params=params, timeout=10)
-            resp.raise_for_status()
-            track_data = resp.json().get("track", {})
-            if not track_data:
-                return None
+        # ── Last.fm ──────────────────────────────────────────────────────────
+        if settings.lastfm_api_key:
+            try:
+                params = {
+                    "method":      "track.getInfo",
+                    "track":       title,
+                    "artist":      artist,
+                    "api_key":     settings.lastfm_api_key,
+                    "format":      "json",
+                    "autocorrect": 1,
+                }
+                resp = requests.get(_LASTFM_BASE, params=params, timeout=10)
+                resp.raise_for_status()
+                track_data = resp.json().get("track", {})
+                if track_data:
+                    listeners = int(track_data.get("listeners", 0))
+                    playcount = int(track_data.get("playcount", 0))
+            except Exception:  # noqa: BLE001 — popularity is always best-effort
+                pass
 
-            listeners = int(track_data.get("listeners", 0))
-            playcount = int(track_data.get("playcount", 0))
-            return _classify_popularity(listeners, playcount)
+        # ── Spotify ───────────────────────────────────────────────────────────
+        if settings.spotify_client_id and settings.spotify_client_secret:
+            spotify_score = _fetch_spotify_popularity(
+                title, artist,
+                settings.spotify_client_id,
+                settings.spotify_client_secret,
+            )
 
-        except Exception:  # noqa: BLE001 — popularity is always best-effort
+        # ── Bail if nothing at all ────────────────────────────────────────────
+        if not listeners and not playcount and spotify_score is None and not metrics:
             return None
+
+        return _classify_popularity(
+            listeners=listeners,
+            playcount=playcount,
+            spotify_score=spotify_score,
+            platform_metrics=metrics,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -297,33 +331,118 @@ def _resolve_youtube_url(artist: str, title: str) -> Optional[str]:
     return None
 
 
+def _piecewise_score(value: int, low: int, mid: int, high: int) -> int:
+    """
+    Map a raw count to a 0–100 score using three tier-boundary breakpoints.
+
+    Segments:
+      0        → low:  scores 0–25  (Emerging range)
+      low      → mid:  scores 25–50 (Regional range)
+      mid      → high: scores 50–75 (Mainstream range)
+      high     → ∞:    scores 75–100, clamped at 100 (Global range)
+
+    Breakpoints correspond directly to the tier boundaries in SystemConstants,
+    so each tier segment occupies exactly 25 points of score space.
+
+    Pure function — no I/O.
+    """
+    if value <= 0:
+        return 0
+    if value >= high:
+        # Linear continuation above high ceiling, clamped at 100
+        extra = min(value - high, high) / high * 25
+        return min(100, 75 + int(extra))
+    if value >= mid:
+        return 50 + int((value - mid) / (high - mid) * 25)
+    if value >= low:
+        return 25 + int((value - low) / (mid - low) * 25)
+    return int(value / low * 25)
+
+
+def _normalise_lastfm(listeners: int, constants: object) -> int:
+    """
+    Normalise a Last.fm listener count to a 0–100 score.
+
+    Breakpoints: LASTFM_LISTENERS_REGIONAL / _MAINSTREAM / _GLOBAL → 25/50/75.
+
+    Pure function — no I/O.
+    """
+    cfg = constants
+    return _piecewise_score(
+        listeners,
+        cfg.LASTFM_LISTENERS_REGIONAL,
+        cfg.LASTFM_LISTENERS_MAINSTREAM,
+        cfg.LASTFM_LISTENERS_GLOBAL,
+    )
+
+
+def _normalise_views(view_count: int, constants: object) -> int:
+    """
+    Normalise a platform view count to a 0–100 score.
+
+    Breakpoints: PLATFORM_VIEWS_REGIONAL / _MAINSTREAM / _GLOBAL → 25/50/75.
+
+    Pure function — no I/O.
+    """
+    cfg = constants
+    return _piecewise_score(
+        view_count,
+        cfg.PLATFORM_VIEWS_REGIONAL,
+        cfg.PLATFORM_VIEWS_MAINSTREAM,
+        cfg.PLATFORM_VIEWS_GLOBAL,
+    )
+
+
 def _classify_popularity(
     listeners: int,
     playcount: int,
+    spotify_score: Optional[int] = None,
+    platform_metrics: Optional[dict[str, int]] = None,
     constants: object | None = None,
 ) -> PopularityResult:
     """
-    Classify a track's popularity tier and estimate sync cost range.
+    Derive a blended popularity_score and tier from all available signals.
 
-    Tier boundaries and cost ranges come from SystemConstants — no magic numbers.
+    Strategy: normalise each signal independently to 0–100, then take the
+    maximum.  This means a strong signal on any single platform cannot be
+    suppressed by a weak or missing one — a track with 200M YouTube views
+    will not show as "Emerging" just because Last.fm has a bad listener count.
+
+    Signals used (each optional — omitted when unavailable):
+      - Last.fm listeners (piecewise-linear normalised against tier boundaries)
+      - Spotify popularity (native 0–100, passed through directly)
+      - Platform view_count from platform_metrics (piecewise-linear normalised)
+
+    Tier boundaries and cost ranges come from SystemConstants.
     Accepts an optional constants override for unit testing without env deps.
 
-    Args:
-        listeners:  Last.fm unique listener count.
-        playcount:  Last.fm total scrobble count.
-        constants:  Optional SystemConstants instance; defaults to CONSTANTS.
-
-    Returns:
-        PopularityResult with tier and estimated sync cost range.
+    Pure function — no I/O.
     """
     cfg = constants or CONSTANTS
-    if listeners >= cfg.POPULARITY_GLOBAL_MIN:
+    metrics = platform_metrics or {}
+
+    scores: list[int] = []
+
+    lastfm_score = _normalise_lastfm(listeners, cfg)
+    if lastfm_score > 0:
+        scores.append(lastfm_score)
+
+    if spotify_score is not None:
+        scores.append(max(0, min(100, spotify_score)))
+
+    view_count = metrics.get("view_count", 0)
+    if view_count > 0:
+        scores.append(_normalise_views(view_count, cfg))
+
+    popularity_score = max(scores) if scores else 0
+
+    if popularity_score >= cfg.POPULARITY_GLOBAL_MIN:
         tier                = "Global"
         cost_low, cost_high = cfg.SYNC_COST_GLOBAL
-    elif listeners >= cfg.POPULARITY_MAINSTREAM_MIN:
+    elif popularity_score >= cfg.POPULARITY_MAINSTREAM_MIN:
         tier                = "Mainstream"
         cost_low, cost_high = cfg.SYNC_COST_MAINSTREAM
-    elif listeners >= cfg.POPULARITY_REGIONAL_MIN:
+    elif popularity_score >= cfg.POPULARITY_REGIONAL_MIN:
         tier                = "Regional"
         cost_low, cost_high = cfg.SYNC_COST_REGIONAL
     else:
@@ -333,10 +452,65 @@ def _classify_popularity(
     return PopularityResult(
         listeners=listeners,
         playcount=playcount,
+        spotify_score=spotify_score,
+        platform_metrics=metrics,
+        popularity_score=popularity_score,
         tier=tier,
         sync_cost_low=cost_low,
         sync_cost_high=cost_high,
     )
+
+
+def _fetch_spotify_popularity(
+    title: str,
+    artist: str,
+    client_id: str,
+    client_secret: str,
+) -> Optional[int]:
+    """
+    Fetch Spotify popularity score (0–100) via the Web API search endpoint.
+
+    Uses client credentials OAuth — no user login required.  The token is
+    fetched fresh on each call; caching across calls is intentionally omitted
+    here because popularity is already a best-effort supplementary signal and
+    adding token state would complicate testing.
+
+    Returns None on any failure (missing credentials, network error, no match).
+
+    Pure I/O boundary — no business logic.
+    """
+    try:
+        # ── Step 1: client credentials token ─────────────────────────────────
+        credentials = base64.b64encode(
+            f"{client_id}:{client_secret}".encode()
+        ).decode()
+        token_resp = requests.post(
+            "https://accounts.spotify.com/api/token",
+            headers={"Authorization": f"Basic {credentials}"},
+            data={"grant_type": "client_credentials"},
+            timeout=10,
+        )
+        token_resp.raise_for_status()
+        token = token_resp.json().get("access_token", "")
+        if not token:
+            return None
+
+        # ── Step 2: search for the track ──────────────────────────────────────
+        query = f"track:{title} artist:{artist}" if artist else f"track:{title}"
+        search_resp = requests.get(
+            "https://api.spotify.com/v1/search",
+            headers={"Authorization": f"Bearer {token}"},
+            params={"q": query, "type": "track", "limit": 1},
+            timeout=10,
+        )
+        search_resp.raise_for_status()
+        items = search_resp.json().get("tracks", {}).get("items", [])
+        if not items:
+            return None
+
+        return int(items[0].get("popularity", 0))
+    except Exception:  # noqa: BLE001 — Spotify is always best-effort
+        return None
 
 
 def _find_binary(name: str) -> Optional[str]:

--- a/services/ingestion.py
+++ b/services/ingestion.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import io
 import json
 import re
+import shlex
 import shutil
 import subprocess
 import urllib.request
@@ -55,6 +56,16 @@ _FACEBOOK_HOSTS: frozenset[str] = frozenset({
 _DIRECT_AUDIO_EXTENSIONS: frozenset[str] = frozenset({
     ".mp3", ".wav", ".flac", ".ogg", ".m4a", ".aac",
 })
+
+# Engagement fields requested from yt-dlp --print for popularity signals.
+# One field per line (newline separator avoids comma-in-value misalignment).
+_ENGAGEMENT_FIELDS: list[str] = [
+    "view_count",
+    "like_count",
+    "share_count",
+    "repost_count",
+    "channel_follower_count",
+]
 
 
 class Ingestion:
@@ -132,6 +143,7 @@ class Ingestion:
         # two consecutive requests for the same video. --dump-json is a
         # lightweight info-only call (~2s); the download follows separately.
         track_metadata = _fetch_youtube_metadata(url, ytdlp_bin)
+        track_metadata.update(_fetch_platform_engagement(url, ytdlp_bin))
 
         ytdlp_cmd = [
             ytdlp_bin,
@@ -459,6 +471,58 @@ def _fetch_youtube_metadata(url: str, ytdlp_bin: str) -> dict[str, str]:
         return {"title": _clean_title(title_raw), "artist": artist}
     except Exception:  # noqa: BLE001 — metadata is always best-effort
         return {"title": "", "artist": ""}
+
+
+def _fetch_platform_engagement(url: str, ytdlp_bin: str) -> dict[str, int]:
+    """
+    Fetch per-platform engagement metrics for a URL via yt-dlp --print.
+
+    Returns a flat dict of whichever integer fields yt-dlp exposes for the
+    platform (e.g. view_count, like_count, share_count, repost_count).
+    Fields absent or non-integer for a given platform are omitted.
+
+    This is a lightweight info-only call — no audio is downloaded.
+    Never raises — engagement data is always supplementary.
+
+    Supported platforms and available fields:
+      YouTube:    view_count, like_count, channel_follower_count
+      TikTok:     view_count, like_count, share_count, repost_count
+      Instagram:  view_count, like_count
+      Facebook:   view_count, like_count
+      SoundCloud: view_count (plays), like_count, repost_count
+    """
+    # One field per line — newline separator avoids misalignment when
+    # yt-dlp formats numbers with commas (e.g. "1,234,567").
+    print_template = "\n".join(f"%({f})s" for f in _ENGAGEMENT_FIELDS)
+    try:
+        result = subprocess.run(
+            [
+                ytdlp_bin,
+                "--quiet",
+                "--no-warnings",
+                "--no-playlist",
+                "--print", print_template,
+                shlex.quote(url),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return {}
+
+        lines = result.stdout.splitlines()
+        metrics: dict[str, int] = {}
+        for field, raw in zip(_ENGAGEMENT_FIELDS, lines):
+            raw = raw.strip()
+            if raw and raw not in ("NA", "None", "none"):
+                try:
+                    metrics[field] = int(float(raw.replace(",", "")))
+                except ValueError:
+                    pass
+        return metrics
+    except Exception:  # noqa: BLE001 — engagement data is always best-effort
+        return {}
 
 
 def _artist_from_uploader(uploader: str) -> str:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -10,11 +10,48 @@ from services.discovery import (
     Discovery,
     _classify_popularity,
     _find_binary,
+    _normalise_lastfm,
+    _normalise_views,
     _parse_track_list,
     _resolve_youtube_url,
 )
 from core.config import CONSTANTS
 from core.exceptions import ConfigurationError
+
+
+# ---------------------------------------------------------------------------
+# _normalise_lastfm / _normalise_views (pure helpers — no mocks needed)
+# ---------------------------------------------------------------------------
+
+class TestNormaliseLastfm:
+    def test_zero_listeners_returns_zero(self) -> None:
+        assert _normalise_lastfm(0, CONSTANTS) == 0
+
+    def test_global_ceiling_returns_75(self) -> None:
+        # The global boundary maps to exactly 75 — above it extends toward 100
+        assert _normalise_lastfm(CONSTANTS.LASTFM_LISTENERS_GLOBAL, CONSTANTS) == 75
+
+    def test_above_ceiling_clamped_to_100(self) -> None:
+        assert _normalise_lastfm(CONSTANTS.LASTFM_LISTENERS_GLOBAL * 10, CONSTANTS) == 100
+
+    def test_small_count_returns_low_score(self) -> None:
+        assert _normalise_lastfm(100, CONSTANTS) < 30
+
+
+class TestNormaliseViews:
+    def test_zero_views_returns_zero(self) -> None:
+        assert _normalise_views(0, CONSTANTS) == 0
+
+    def test_global_ceiling_returns_75(self) -> None:
+        # The global boundary maps to exactly 75 — above it extends toward 100
+        assert _normalise_views(CONSTANTS.PLATFORM_VIEWS_GLOBAL, CONSTANTS) == 75
+
+    def test_above_ceiling_clamped_to_100(self) -> None:
+        assert _normalise_views(CONSTANTS.PLATFORM_VIEWS_GLOBAL * 2, CONSTANTS) == 100
+
+    def test_1m_views_returns_low_score(self) -> None:
+        score = _normalise_views(1_000_000, CONSTANTS)
+        assert 0 < score < 50
 
 
 # ---------------------------------------------------------------------------
@@ -25,36 +62,60 @@ class TestClassifyPopularity:
     """Tests for _classify_popularity — uses CONSTANTS directly so tier boundaries
     come from config, not magic numbers in tests."""
 
-    def test_emerging_tier(self) -> None:
-        result = _classify_popularity(5_000, 50_000, CONSTANTS)
+    def test_emerging_tier_lastfm_only(self) -> None:
+        result = _classify_popularity(5_000, 50_000, constants=CONSTANTS)
         assert result.tier == "Emerging"
         assert result.listeners == 5_000
         assert result.playcount == 50_000
         assert result.sync_cost_low  == CONSTANTS.SYNC_COST_EMERGING[0]
         assert result.sync_cost_high == CONSTANTS.SYNC_COST_EMERGING[1]
 
-    def test_regional_tier_at_boundary(self) -> None:
-        result = _classify_popularity(CONSTANTS.POPULARITY_REGIONAL_MIN, 0, CONSTANTS)
-        assert result.tier == "Regional"
-
-    def test_mainstream_tier_at_boundary(self) -> None:
-        result = _classify_popularity(CONSTANTS.POPULARITY_MAINSTREAM_MIN, 0, CONSTANTS)
-        assert result.tier == "Mainstream"
-
-    def test_global_tier_at_boundary(self) -> None:
-        result = _classify_popularity(CONSTANTS.POPULARITY_GLOBAL_MIN, 0, CONSTANTS)
-        assert result.tier == "Global"
-        assert result.sync_cost_low  == CONSTANTS.SYNC_COST_GLOBAL[0]
-        assert result.sync_cost_high == CONSTANTS.SYNC_COST_GLOBAL[1]
-
     def test_zero_listeners(self) -> None:
-        result = _classify_popularity(0, 0, CONSTANTS)
+        result = _classify_popularity(0, 0, constants=CONSTANTS)
         assert result.tier == "Emerging"
-        assert result.listeners == 0
+        assert result.popularity_score == 0
 
-    def test_just_below_regional(self) -> None:
-        result = _classify_popularity(CONSTANTS.POPULARITY_REGIONAL_MIN - 1, 0, CONSTANTS)
+    def test_spotify_score_elevates_tier(self) -> None:
+        # 10 Last.fm listeners alone → Emerging, but Spotify score of 80 → Global
+        result = _classify_popularity(10, 0, spotify_score=80, constants=CONSTANTS)
+        assert result.tier == "Global"
+        assert result.spotify_score == 80
+
+    def test_high_view_count_elevates_tier(self) -> None:
+        # 1 Last.fm listener, but 300M YouTube views → should be Mainstream or Global
+        result = _classify_popularity(
+            1, 0,
+            platform_metrics={"view_count": 300_000_000},
+            constants=CONSTANTS,
+        )
+        assert result.tier in ("Mainstream", "Global")
+
+    def test_bad_lastfm_overridden_by_youtube_views(self) -> None:
+        # Simulates the "24K Magic shows as Emerging" bug:
+        # 13 Last.fm listeners + 500M YouTube views → should NOT be Emerging
+        result = _classify_popularity(
+            13, 0,
+            platform_metrics={"view_count": 500_000_000},
+            constants=CONSTANTS,
+        )
+        assert result.tier != "Emerging"
+
+    def test_max_of_signals_taken(self) -> None:
+        # Spotify score 60 > last.fm score → popularity_score should equal 60
+        result = _classify_popularity(
+            100, 0, spotify_score=60, constants=CONSTANTS
+        )
+        assert result.popularity_score == 60
+
+    def test_platform_metrics_stored(self) -> None:
+        metrics = {"view_count": 1_000_000, "like_count": 50_000}
+        result = _classify_popularity(0, 0, platform_metrics=metrics, constants=CONSTANTS)
+        assert result.platform_metrics == metrics
+
+    def test_no_signals_returns_emerging(self) -> None:
+        result = _classify_popularity(0, 0, constants=CONSTANTS)
         assert result.tier == "Emerging"
+        assert result.popularity_score == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -128,6 +128,16 @@ class TestFetchYoutubeAudio:
 
     def setup_method(self):
         self.svc = Ingestion()
+        # _fetch_platform_engagement uses subprocess.run; patch it to a no-op
+        # so these tests don't require yt-dlp on PATH.
+        self._run_patcher = patch(
+            "services.ingestion.subprocess.run",
+            return_value=MagicMock(returncode=1, stdout=""),
+        )
+        self._run_patcher.start()
+
+    def teardown_method(self):
+        self._run_patcher.stop()
 
     def test_returns_audio_buffer_on_success(self):
         wav = b"RIFF\x00\x00\x00\x00WAVEfmt "

--- a/ui/pages/loading.py
+++ b/ui/pages/loading.py
@@ -634,7 +634,15 @@ def render_loading(source: Any) -> None:
             base_links    = Legal().get_links(title, artist)
             isrc, pro     = ProLookup().lookup(title, artist)
             legal         = base_links.model_copy(update={"isrc": isrc, "pro_match": pro})
-            popularity    = Discovery().get_track_popularity(title, artist)
+            popularity    = Discovery().get_track_popularity(
+                title, artist,
+                platform_metrics={
+                    k: v for k, v in (audio.metadata or {}).items()
+                    if k in ("view_count", "like_count", "share_count",
+                             "repost_count", "channel_follower_count")
+                    and isinstance(v, int)
+                },
+            )
             audio_quality = AudioQualityAnalyzer().analyze(audio)
     except StepTimeoutError as exc:
         st.toast("⏱ Legal/loudness step timed out — PRO links and loudness data unavailable.", icon="⚠️")


### PR DESCRIPTION
Fixes #73

## Summary
- Replaces single Last.fm listener count with a blended 0-100 popularity_score derived from whichever signals are available
- Adds Spotify Web API integration (client credentials OAuth, no user login)
- Captures platform engagement metrics (view_count, like_count, share_count etc.) via yt-dlp at download time
- Piecewise-linear normalisation tied to tier boundaries — each tier occupies 25 score points
- Takes the max across all signals so a bad Last.fm lookup cannot suppress a mainstream track

## Test plan
- [ ] 443 tests passing
- [ ] Bruno Mars '24K Magic' no longer shows as Emerging when YouTube view count is available
- [ ] Spotify credentials optional — graceful fallback when absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)