### PR TITLE
fix(discovery): signal gate for popularity tiers + fuzzy Last.fm fallback

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -215,6 +215,21 @@ class SystemConstants:
     PLATFORM_VIEWS_MAINSTREAM: int  = 50_000_000    # 50M views → score ~50
     PLATFORM_VIEWS_GLOBAL: int      = 500_000_000   # 500M views → score ~75+
 
+    # Minimum number of independent signals required to award higher tiers.
+    # Protects against false highs (e.g. a meme remix with 200M views but
+    # near-zero Last.fm + Spotify scores reaching Global).
+    # Emerging/Regional: 1 signal sufficient (single source is credible enough).
+    # Mainstream: at least 2 signals must score > 0.
+    # Global: at least 2 signals must score > 0.
+    POPULARITY_MIN_SIGNALS_MAINSTREAM: int = 2
+    POPULARITY_MIN_SIGNALS_GLOBAL: int     = 2
+
+    # Last.fm listener threshold below which a fuzzy retry is attempted.
+    # If the first lookup returns fewer listeners than this, strip featured
+    # artists and parenthetical suffixes and retry — covers "13 listeners for
+    # Bruno Mars" cases caused by title decoration mismatches in Last.fm's index.
+    LASTFM_LOW_LISTENER_THRESHOLD: int = 1_000
+
     # Estimated sync fee ranges (USD) per popularity tier — shown as guidance only.
     # Source: industry averages 2024-2026; highly variable by usage and territory.
     SYNC_COST_EMERGING: tuple[int, int]    = (500,    5_000)

--- a/services/discovery.py
+++ b/services/discovery.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import base64
 import math
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -150,6 +151,27 @@ class Discovery:
                 if track_data:
                     listeners = int(track_data.get("listeners", 0))
                     playcount = int(track_data.get("playcount", 0))
+
+                # ── Fuzzy retry (#89) ─────────────────────────────────────
+                # If the first lookup returns suspiciously few listeners
+                # (e.g. Bruno Mars / 24K Magic showing 13 due to decorated
+                # title mismatch), strip feat./parentheticals and retry once.
+                if listeners < CONSTANTS.LASTFM_LOW_LISTENER_THRESHOLD:
+                    clean_title = _clean_title_for_lastfm(title)
+                    if clean_title and clean_title != title:
+                        retry_params = {**params, "track": clean_title}
+                        retry_resp = requests.get(
+                            _LASTFM_BASE, params=retry_params, timeout=10
+                        )
+                        retry_resp.raise_for_status()
+                        retry_data = retry_resp.json().get("track", {})
+                        if retry_data:
+                            retry_listeners = int(retry_data.get("listeners", 0))
+                            retry_playcount = int(retry_data.get("playcount", 0))
+                            # Only upgrade — never downgrade to the cleaned result
+                            if retry_listeners > listeners:
+                                listeners = retry_listeners
+                                playcount = max(playcount, retry_playcount)
             except Exception:  # noqa: BLE001 — popularity is always best-effort
                 pass
 
@@ -393,6 +415,37 @@ def _normalise_views(view_count: int, constants: object) -> int:
     )
 
 
+def _clean_title_for_lastfm(title: str) -> str:
+    """
+    Strip common title decorations that cause Last.fm lookup mismatches.
+
+    Removes:
+      - Featured artist credits: "feat. X", "ft. X", "featuring X"
+      - Parenthetical / bracket suffixes: "(Official Video)", "[Lyrics]", etc.
+      - Leading/trailing whitespace
+
+    Designed for use as a fuzzy retry when the first lookup returns
+    suspiciously low listener counts (< LASTFM_LOW_LISTENER_THRESHOLD).
+
+    Pure function — no I/O.
+
+    >>> _clean_title_for_lastfm("24K Magic (feat. Bruno Mars) [Lyrics]")
+    '24K Magic'
+    >>> _clean_title_for_lastfm("Blinding Lights")
+    'Blinding Lights'
+    """
+    # Strip "feat." / "ft." / "featuring" blocks (with optional parentheses)
+    cleaned = re.sub(
+        r"\s*[\(\[]?\s*(?:feat\.?|ft\.?|featuring)\s+[^\)\]]+[\)\]]?",
+        "",
+        title,
+        flags=re.IGNORECASE,
+    )
+    # Strip any remaining trailing parenthetical / bracket suffixes
+    cleaned = re.sub(r"\s*[\(\[][^\)\]]+[\)\]]\s*$", "", cleaned, flags=re.IGNORECASE)
+    return cleaned.strip()
+
+
 def _classify_popularity(
     listeners: int,
     playcount: int,
@@ -403,10 +456,17 @@ def _classify_popularity(
     """
     Derive a blended popularity_score and tier from all available signals.
 
-    Strategy: normalise each signal independently to 0–100, then take the
-    maximum.  This means a strong signal on any single platform cannot be
-    suppressed by a weak or missing one — a track with 200M YouTube views
-    will not show as "Emerging" just because Last.fm has a bad listener count.
+    Strategy: normalise each signal independently to 0–100, take the maximum,
+    then apply a minimum-signal gate for higher tiers.
+
+    max() protects against false lows (a bad Last.fm lookup can't suppress a
+    mainstream track).  The signal gate protects against false highs (a meme
+    remix with 200M views but near-zero Last.fm + Spotify can't reach Global).
+
+    Gate rules (from SystemConstants):
+      Emerging / Regional: 1 signal sufficient
+      Mainstream:          requires POPULARITY_MIN_SIGNALS_MAINSTREAM signals > 0
+      Global:              requires POPULARITY_MIN_SIGNALS_GLOBAL signals > 0
 
     Signals used (each optional — omitted when unavailable):
       - Last.fm listeners (piecewise-linear normalised against tier boundaries)
@@ -435,11 +495,17 @@ def _classify_popularity(
         scores.append(_normalise_views(view_count, cfg))
 
     popularity_score = max(scores) if scores else 0
+    signal_count = len(scores)
 
-    if popularity_score >= cfg.POPULARITY_GLOBAL_MIN:
+    # Determine tier, applying the minimum-signal gate to higher tiers.
+    # If the score qualifies for a tier but not enough signals are present,
+    # cap at the next tier down.
+    if (popularity_score >= cfg.POPULARITY_GLOBAL_MIN
+            and signal_count >= cfg.POPULARITY_MIN_SIGNALS_GLOBAL):
         tier                = "Global"
         cost_low, cost_high = cfg.SYNC_COST_GLOBAL
-    elif popularity_score >= cfg.POPULARITY_MAINSTREAM_MIN:
+    elif (popularity_score >= cfg.POPULARITY_MAINSTREAM_MIN
+            and signal_count >= cfg.POPULARITY_MIN_SIGNALS_MAINSTREAM):
         tier                = "Mainstream"
         cost_low, cost_high = cfg.SYNC_COST_MAINSTREAM
     elif popularity_score >= cfg.POPULARITY_REGIONAL_MIN:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -9,6 +9,7 @@ import pytest
 from services.discovery import (
     Discovery,
     _classify_popularity,
+    _clean_title_for_lastfm,
     _find_binary,
     _normalise_lastfm,
     _normalise_views,
@@ -76,19 +77,25 @@ class TestClassifyPopularity:
         assert result.popularity_score == 0
 
     def test_spotify_score_elevates_tier(self) -> None:
-        # 10 Last.fm listeners alone → Emerging, but Spotify score of 80 → Global
+        # Spotify score of 80 alone scores high, but the signal gate requires
+        # POPULARITY_MIN_SIGNALS_GLOBAL signals for Global — so with only 1
+        # signal the tier is capped below Global.
         result = _classify_popularity(10, 0, spotify_score=80, constants=CONSTANTS)
-        assert result.tier == "Global"
+        assert result.tier != "Emerging"          # score is elevated
+        assert result.tier != "Global"            # gate fires — not enough signals
         assert result.spotify_score == 80
 
     def test_high_view_count_elevates_tier(self) -> None:
-        # 1 Last.fm listener, but 300M YouTube views → should be Mainstream or Global
+        # 300M YouTube views is a strong signal, but with only 1 signal the
+        # Mainstream gate fires (requires POPULARITY_MIN_SIGNALS_MAINSTREAM).
+        # Score is elevated well above Emerging though.
         result = _classify_popularity(
             1, 0,
             platform_metrics={"view_count": 300_000_000},
             constants=CONSTANTS,
         )
-        assert result.tier in ("Mainstream", "Global")
+        assert result.tier not in ("Emerging",)   # score is elevated
+        assert result.popularity_score > 25        # clearly above Emerging range
 
     def test_bad_lastfm_overridden_by_youtube_views(self) -> None:
         # Simulates the "24K Magic shows as Emerging" bug:
@@ -265,3 +272,165 @@ class TestDiscovery:
             results = svc.find_similar("Title", "Artist")
 
         assert all(r.youtube_url is None for r in results)
+
+
+# ---------------------------------------------------------------------------
+# _classify_popularity — signal gate (#88)
+# ---------------------------------------------------------------------------
+
+class TestSignalGate:
+    """Tests for the minimum-signal gate that guards Mainstream/Global tiers."""
+
+    def test_single_high_view_count_capped_at_regional_not_mainstream(self) -> None:
+        # 50M views → score 50 (Mainstream boundary), but only 1 signal — gate fires
+        result = _classify_popularity(
+            0, 0,
+            platform_metrics={"view_count": CONSTANTS.PLATFORM_VIEWS_MAINSTREAM},
+            constants=CONSTANTS,
+        )
+        # With only 1 signal and POPULARITY_MIN_SIGNALS_MAINSTREAM == 2, tier is capped
+        assert result.tier in ("Regional", "Emerging")
+
+    def test_two_signals_unlocks_mainstream(self) -> None:
+        # Last.fm + views together satisfy the 2-signal gate
+        result = _classify_popularity(
+            CONSTANTS.LASTFM_LISTENERS_MAINSTREAM,  # score 50
+            0,
+            platform_metrics={"view_count": CONSTANTS.PLATFORM_VIEWS_MAINSTREAM},  # score 50
+            constants=CONSTANTS,
+        )
+        assert result.tier == "Mainstream"
+
+    def test_single_spotify_score_capped_below_global(self) -> None:
+        # Spotify 90 alone → score 90, but 1 signal → Global gate fires
+        result = _classify_popularity(0, 0, spotify_score=90, constants=CONSTANTS)
+        assert result.tier != "Global"
+
+    def test_two_signals_unlocks_global(self) -> None:
+        # Spotify 80 + Last.fm at global boundary → both score ≥ 75, 2 signals
+        result = _classify_popularity(
+            CONSTANTS.LASTFM_LISTENERS_GLOBAL,
+            0,
+            spotify_score=80,
+            constants=CONSTANTS,
+        )
+        assert result.tier == "Global"
+
+    def test_signal_count_stored_in_popularity_score(self) -> None:
+        # When two signals are present the blended score is max of both
+        result = _classify_popularity(
+            100, 0, spotify_score=60, constants=CONSTANTS
+        )
+        assert result.popularity_score == 60
+
+
+# ---------------------------------------------------------------------------
+# _clean_title_for_lastfm — fuzzy Last.fm fallback (#89)
+# ---------------------------------------------------------------------------
+
+class TestCleanTitleForLastfm:
+    def test_strips_feat_dot(self) -> None:
+        assert _clean_title_for_lastfm("24K Magic (feat. Bruno Mars)") == "24K Magic"
+
+    def test_strips_ft_dot(self) -> None:
+        assert _clean_title_for_lastfm("Song (ft. Artist)") == "Song"
+
+    def test_strips_featuring(self) -> None:
+        assert _clean_title_for_lastfm("Track featuring Someone") == "Track"
+
+    def test_strips_bracket_suffix(self) -> None:
+        assert _clean_title_for_lastfm("Mr. Brightside [Official Video]") == "Mr. Brightside"
+
+    def test_strips_bare_parenthetical(self) -> None:
+        assert _clean_title_for_lastfm("Blue (Extended Version)") == "Blue"
+
+    def test_clean_title_unchanged(self) -> None:
+        assert _clean_title_for_lastfm("Blinding Lights") == "Blinding Lights"
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert _clean_title_for_lastfm("") == ""
+
+    def test_feat_inline_without_parens(self) -> None:
+        result = _clean_title_for_lastfm("Sunflower feat. Swae Lee")
+        assert "feat" not in result.lower()
+        assert "Sunflower" in result
+
+
+# ---------------------------------------------------------------------------
+# get_track_popularity — fuzzy Last.fm retry integration test (#89)
+# ---------------------------------------------------------------------------
+
+class TestFuzzyLastfmRetry:
+    """
+    Verifies that get_track_popularity() retries with a cleaned title when
+    the first Last.fm lookup returns suspiciously few listeners.
+    """
+
+    def _make_settings(self):
+        s = MagicMock()
+        s.lastfm_api_key = "fakekey"
+        s.spotify_client_id = ""
+        s.spotify_client_secret = ""
+        return s
+
+    def test_retry_fires_and_upgrades_listeners(self) -> None:
+        """First call returns 13 listeners; retry returns 1_500_000."""
+        low_resp = MagicMock()
+        low_resp.raise_for_status.return_value = None
+        low_resp.json.return_value = {
+            "track": {"listeners": "13", "playcount": "50"}
+        }
+
+        high_resp = MagicMock()
+        high_resp.raise_for_status.return_value = None
+        high_resp.json.return_value = {
+            "track": {"listeners": "1500000", "playcount": "10000000"}
+        }
+
+        with patch("services.discovery.get_settings", return_value=self._make_settings()), \
+             patch("services.discovery.requests.get", side_effect=[low_resp, high_resp]):
+            svc = Discovery()
+            result = svc.get_track_popularity(
+                "24K Magic (feat. Bruno Mars)", "Bruno Mars"
+            )
+
+        assert result is not None
+        assert result.listeners == 1_500_000
+
+    def test_retry_does_not_downgrade(self) -> None:
+        """If the retry returns fewer listeners, keep the original."""
+        first_resp = MagicMock()
+        first_resp.raise_for_status.return_value = None
+        first_resp.json.return_value = {
+            "track": {"listeners": "500", "playcount": "2000"}
+        }
+
+        lower_resp = MagicMock()
+        lower_resp.raise_for_status.return_value = None
+        lower_resp.json.return_value = {
+            "track": {"listeners": "10", "playcount": "100"}
+        }
+
+        with patch("services.discovery.get_settings", return_value=self._make_settings()), \
+             patch("services.discovery.requests.get", side_effect=[first_resp, lower_resp]):
+            svc = Discovery()
+            result = svc.get_track_popularity("Song (feat. X)", "Artist")
+
+        assert result is not None
+        assert result.listeners == 500
+
+    def test_no_retry_when_clean_title_unchanged(self) -> None:
+        """If the title has no decorations, the retry should not fire (only 1 HTTP call)."""
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {
+            "track": {"listeners": "200", "playcount": "1000"}
+        }
+
+        with patch("services.discovery.get_settings", return_value=self._make_settings()), \
+             patch("services.discovery.requests.get", return_value=resp) as mock_get:
+            svc = Discovery()
+            svc.get_track_popularity("Blinding Lights", "The Weeknd")
+
+        # Only 1 call — no retry needed because title has no decorations
+        assert mock_get.call_count == 1

--- a/ui/pages/report.py
+++ b/ui/pages/report.py
@@ -152,6 +152,10 @@ def render_report(
     with st.expander("Structural Repetition", expanded=True):
         _render_production_analysis_card(result.forensics)
 
+    if result.sync_cuts:
+        with st.expander("Sync Edit Points", expanded=False):
+            _render_sync_cuts(result)
+
     with st.expander("Sync Readiness Checks", expanded=True):
         _render_sync_readiness(result.compliance)
         _render_audio_quality_card(result.audio_quality)
@@ -161,10 +165,6 @@ def render_report(
 
     with st.expander("Lyrics & Content Audit", expanded=True):
         _render_lyric_section(result)
-
-    if result.sync_cuts:
-        with st.expander("Sync Edit Points", expanded=False):
-            _render_sync_cuts(result)
 
     _render_export_buttons(result)
     _render_footer()


### PR DESCRIPTION
## Summary
- Adds minimum signal count gate (2 signals required) before awarding Mainstream/Global tiers — prevents a single-platform outlier (e.g. meme remix with 200M views but no Last.fm/Spotify presence) from inflating the tier
- Adds `_clean_title_for_lastfm()` pure function that strips feat./parentheticals, with a fuzzy retry in `get_track_popularity()` when the first lookup returns suspiciously few listeners (< `LASTFM_LOW_LISTENER_THRESHOLD`)
- Retry is upgrade-only — never downgrades to the cleaned result
- Moves Sync Edit Points section below Structural Repetition in the report page

## Closes
Closes #88, #89, #83

## Test plan
- [ ] 459 tests pass (`pytest tests/ -q`)
- [ ] `TestSignalGate` — 5 tests covering single-signal cap and two-signal unlock for Mainstream/Global
- [ ] `TestCleanTitleForLastfm` — 8 tests covering feat., ft., featuring, bracket/paren suffixes, clean titles
- [ ] `TestFuzzyLastfmRetry` — 3 integration tests: upgrade fires, downgrade suppressed, no retry on clean title

🤖 Generated with [Claude Code](https://claude.com/claude-code)